### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2024"
 description = "SDK for the Anthropic API"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claudius
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)
-![Version](https://img.shields.io/badge/version-0.11.0-green.svg)
+![Version](https://img.shields.io/badge/version-0.12.0-green.svg)
 
 Claudius is a comprehensive Rust SDK for the Anthropic API, providing both low-level API access and a 
 powerful agent framework for building AI-powered applications. This library enables seamless integration 
@@ -71,7 +71,7 @@ Add Claudius to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-claudius = "0.11.0"
+claudius = "0.12.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
Update version number from 0.11.0 to 0.12.0 in both Cargo.toml
and README.md for consistency across package metadata and
documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
