### PR TITLE
refactor: remove HTTP/2 prior knowledge from client configuration

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -57,7 +57,6 @@ impl Anthropic {
             .pool_max_idle_per_host(10) // Connection pooling optimization
             .pool_idle_timeout(Duration::from_secs(90))
             .tcp_keepalive(Duration::from_secs(60))
-            .http2_prior_knowledge() // Use HTTP/2 for better performance
             .build()
             .map_err(|e| {
                 Error::http_client(
@@ -101,7 +100,6 @@ impl Anthropic {
             .pool_max_idle_per_host(10)
             .pool_idle_timeout(Duration::from_secs(90))
             .tcp_keepalive(Duration::from_secs(60))
-            .http2_prior_knowledge()
             .build()
             .map_err(|e| {
                 Error::http_client(


### PR DESCRIPTION
Remove .http2_prior_knowledge() configuration from both the main client
builder and the timeout reconfiguration builder. This allows the HTTP
client to use default HTTP version negotiation instead of forcing
HTTP/2, which provides better compatibility with various API endpoints
while maintaining other performance optimizations like connection
pooling and TCP keep-alive.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
