### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2024"
 description = "SDK for the Anthropic API"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claudius
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)
-![Version](https://img.shields.io/badge/version-0.12.0-green.svg)
+![Version](https://img.shields.io/badge/version-0.13.0-green.svg)
 
 Claudius is a comprehensive Rust SDK for the Anthropic API, providing both low-level API access and a 
 powerful agent framework for building AI-powered applications. This library enables seamless integration 
@@ -71,7 +71,7 @@ Add Claudius to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-claudius = "0.12.0"
+claudius = "0.13.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
Update version number across project files:
- Cargo.toml: version field updated to 0.13.0
- README.md: version badge and installation example updated

This version includes the new integration tests for streaming and
non-streaming endpoints that were added in previous commits.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: Claude <noreply@anthropic.com>
