### PR TITLE
feat: implement file:// URL support for API keys

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -420,6 +420,11 @@ impl Error {
         matches!(self, Error::ToDo { .. })
     }
 
+    /// Returns true if this error is a validation error.
+    pub fn is_validation(&self) -> bool {
+        matches!(self, Error::Validation { .. })
+    }
+
     /// Returns the request ID associated with this error, if any.
     pub fn request_id(&self) -> Option<&str> {
         match self {


### PR DESCRIPTION
Add support for loading API keys from files using file:// URLs in both
direct parameters and environment variables. This enables secure
storage of API keys in separate files that can be read at runtime.

Features:
- Support for absolute paths: file:///home/user/.env
- Support for relative paths: file://./secret.key
- Automatic whitespace trimming from file contents
- Proper error handling with validation errors for missing files
- Works with CLAUDIUS_API_KEY and ANTHROPIC_API_KEY environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-by: Claude <noreply@anthropic.com>
