### PR TITLE
feat: add relative file resolution for prompt and system references

### DIFF
--- a/prompts/parent_system_test.yaml
+++ b/prompts/parent_system_test.yaml
@@ -1,0 +1,9 @@
+name: "Parent Directory System Test"
+prompt: "What are your key principles?"
+system: "../prompts/system.md"
+model: "claude-3-5-haiku-latest"
+max_tokens: 200
+expected_contains:
+  - "concise"
+  - "direct"
+  - "help"

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -1,0 +1,14 @@
+# System Instructions
+
+You are a helpful AI assistant that follows instructions carefully and provides accurate responses.
+
+## Key Principles
+
+- Be concise and direct
+- Provide factual information
+- Follow user instructions precisely
+- When uncertain, acknowledge limitations
+
+## Response Format
+
+Always respond in a professional and helpful manner.


### PR DESCRIPTION
Implement automatic file resolution for prompt.yaml and system.md references
in test configurations:
- Add resolution for "prompt.yaml" basenames to load file content relative to config
- Add resolution for "system.md" basenames to load file content relative to config
- Support parent directory references like "../system.md" for shared system files
- Maintain security by only resolving specific basenames, not arbitrary paths
- Add comprehensive test coverage for all resolution scenarios

This enables cleaner test configurations that reference external files without
requiring absolute paths or manual content embedding.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-by: Claude <noreply@anthropic.com>
