### PR TITLE
docs: add tool calling test vector and documentation

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -18,6 +18,7 @@ This directory contains test vectors for the `claudius-prompt` binary. These tes
 - `stop_sequence_test.yaml` - Stop sequence functionality
 - `model_comparison.yaml` - Different model testing
 - `json_parsing.yaml` - Structured data parsing
+- `tool_calling_test.yaml` - Custom tool definitions with tool call assertions
 
 ### Edge Cases & Error Conditions
 - `refusal_test.yaml` - Testing AI safety refusal behaviors
@@ -70,6 +71,40 @@ YAML configuration files support the following fields:
 - `min_response_length`: Minimum response length in characters
 - `max_response_length`: Maximum response length in characters
 - `expected_tool_calls`: Array of tool names that should be called (optional)
+- `tools`: Array of tool definitions (see Tool Calling section below)
+- `tool_choice`: Tool selection mode: auto, any, none, or specific tool name
+
+## Tool Calling
+
+Tools are defined as an array of tool objects. Each tool requires:
+
+- `type`: Must be "custom" for user-defined tools
+- `name`: Tool identifier used in assertions and by the model
+- `description`: What the tool does (helps the model decide when to use it)
+- `input_schema`: JSON Schema defining the tool's input parameters
+
+Example:
+```yaml
+tools:
+  - type: "custom"
+    name: "calculator"
+    description: "Performs arithmetic operations"
+    input_schema:
+      type: "object"
+      properties:
+        operation:
+          type: "string"
+          enum: ["add", "subtract", "multiply", "divide"]
+        a:
+          type: "number"
+        b:
+          type: "number"
+      required: ["operation", "a", "b"]
+tool_choice:
+  type: "auto"
+expected_tool_calls:
+  - "calculator"
+```
 
 ## Assertion Testing
 

--- a/prompts/tool_calling_test.yaml
+++ b/prompts/tool_calling_test.yaml
@@ -1,0 +1,44 @@
+name: "Advanced Tool Calling Test"
+prompt: "Calculate the sum of 15 and 27, and then look up the weather in San Francisco."
+system: "You are a helpful assistant with access to tools. Use the calculator tool for math operations and the weather tool to check the weather. Always use tools when appropriate."
+model: "claude-haiku-4-5"
+max_tokens: 1000
+temperature: 0.0
+tools:
+  - type: "custom"
+    name: "calculator"
+    description: "Performs basic arithmetic operations on two numbers. Use this tool whenever the user asks for mathematical calculations."
+    input_schema:
+      type: "object"
+      properties:
+        operation:
+          type: "string"
+          description: "The operation to perform: add, subtract, multiply, or divide"
+          enum: ["add", "subtract", "multiply", "divide"]
+        a:
+          type: "number"
+          description: "The first operand"
+        b:
+          type: "number"
+          description: "The second operand"
+      required: ["operation", "a", "b"]
+  - type: "custom"
+    name: "get_weather"
+    description: "Retrieves the current weather for a specified location. Use this tool when the user asks about weather conditions."
+    input_schema:
+      type: "object"
+      properties:
+        location:
+          type: "string"
+          description: "The city and optionally state/country to get weather for"
+        units:
+          type: "string"
+          description: "Temperature units: celsius or fahrenheit"
+          enum: ["celsius", "fahrenheit"]
+          default: "fahrenheit"
+      required: ["location"]
+tool_choice:
+  type: "auto"
+expected_tool_calls:
+  - "calculator"
+  - "get_weather"


### PR DESCRIPTION
Add tool_calling_test.yaml demonstrating custom tool definitions with:
- Calculator tool with arithmetic operations (add, subtract, multiply, divide)
- Weather lookup tool with location and units parameters
- Tool choice configuration and expected_tool_calls assertions

Update README.md with tool calling documentation:
- Tool definition structure (type, name, description, input_schema)
- JSON Schema format for input parameters
- Complete example showing tools, tool_choice, and assertions

Co-authored-by: AI
