### PR TITLE
feat: add interactive streaming chat REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ serde_yaml = "0.9.34"
 arrrg = "0.8.0"
 arrrg_derive = "0.8.0"
 getopts = "0.2.24"
+rustyline = "17.0.2"
+ctrlc = { version = "3.5.1", features = ["termination"] }
 
 [[bin]]
 name = "median-text"
@@ -38,6 +40,11 @@ required-features=["binaries"]
 [[bin]]
 name = "claudius-prompt"
 path = "src/bin/claudius-prompt.rs"
+required-features=["binaries"]
+
+[[bin]]
+name = "claudius-chat"
+path = "src/bin/claudius-chat.rs"
 required-features=["binaries"]
 
 [dev-dependencies]

--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -1,0 +1,335 @@
+//! Interactive chat application for conversing with Claude.
+//!
+//! This binary provides a streaming REPL interface for chatting with Claude
+//! models via the Anthropic API.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Basic usage with default settings
+//! claudius-chat
+//!
+//! # Specify a model
+//! claudius-chat --model claude-sonnet-4-0
+//!
+//! # Set a system prompt
+//! claudius-chat --system "You are a helpful coding assistant"
+//!
+//! # Disable colors (useful for piping output)
+//! claudius-chat --no-color
+//! ```
+//!
+//! # Commands
+//!
+//! While chatting, you can use slash commands:
+//! - `/help` - Show available commands
+//! - `/clear` - Clear conversation history
+//! - `/model <name>` - Change the model
+//! - `/system [prompt]` - Set or clear system prompt
+//! - `/stats` - Show session statistics
+//! - `/quit` - Exit the application
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use arrrg::CommandLine;
+use rustyline::DefaultEditor;
+use rustyline::error::ReadlineError;
+
+use claudius::chat::{
+    ChatArgs, ChatCommand, ChatConfig, ChatSession, PlainTextRenderer, Renderer, help_text,
+    parse_command,
+};
+use claudius::{Anthropic, Model};
+
+/// Main entry point for the claudius-chat application.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (args, _) = ChatArgs::from_command_line_relaxed("claudius-chat [OPTIONS]");
+    let config = ChatConfig::from(args);
+    let use_color = config.use_color;
+
+    let client = Anthropic::new(None)?;
+    let mut session = ChatSession::new(client, config);
+    let mut renderer = PlainTextRenderer::with_color(use_color);
+    let mut rl = DefaultEditor::new()?;
+
+    // Flag for interrupt handling during streaming
+    let interrupted = Arc::new(AtomicBool::new(false));
+
+    // Set up Ctrl+C handler
+    let interrupted_clone = interrupted.clone();
+    ctrlc::set_handler(move || {
+        interrupted_clone.store(true, Ordering::Relaxed);
+    })?;
+
+    println!("Claude Chat (model: {})", session.model());
+    println!("Type /help for commands, /quit to exit\n");
+
+    loop {
+        // Reset interrupt flag before each input
+        interrupted.store(false, Ordering::Relaxed);
+
+        let readline = rl.readline("You: ");
+
+        match readline {
+            Ok(line) => {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+
+                let _ = rl.add_history_entry(line);
+
+                // Check for slash commands
+                if let Some(cmd) = parse_command(line) {
+                    match cmd {
+                        ChatCommand::Quit => {
+                            println!("Goodbye!");
+                            break;
+                        }
+                        ChatCommand::Clear => {
+                            session.clear();
+                            renderer.print_info("Conversation cleared.");
+                        }
+                        ChatCommand::Help => {
+                            for line in help_text().lines() {
+                                println!("    {}", line);
+                            }
+                        }
+                        ChatCommand::Model(model_name) => {
+                            let model = model_name
+                                .parse()
+                                .unwrap_or_else(|_| Model::Custom(model_name.clone()));
+                            session.set_model(model);
+                            renderer.print_info(&format!("Model changed to: {}", model_name));
+                        }
+                        ChatCommand::System(prompt) => {
+                            session.set_system_prompt(prompt.clone());
+                            match prompt {
+                                Some(p) => {
+                                    renderer.print_info(&format!("System prompt set to: {}", p))
+                                }
+                                None => renderer.print_info("System prompt cleared."),
+                            }
+                        }
+                        ChatCommand::MaxTokens(value) => {
+                            session.set_max_tokens(value);
+                            renderer.print_info(&format!("max_tokens set to {value}"));
+                        }
+                        ChatCommand::Temperature(value) => {
+                            session.set_temperature(Some(value));
+                            renderer.print_info(&format!("temperature set to {:.2}", value));
+                        }
+                        ChatCommand::ClearTemperature => {
+                            session.set_temperature(None);
+                            renderer.print_info("temperature reset to model default");
+                        }
+                        ChatCommand::TopP(value) => {
+                            session.set_top_p(Some(value));
+                            renderer.print_info(&format!("top_p set to {:.2}", value));
+                        }
+                        ChatCommand::ClearTopP => {
+                            session.set_top_p(None);
+                            renderer.print_info("top_p reset to model default");
+                        }
+                        ChatCommand::TopK(value) => {
+                            session.set_top_k(Some(value));
+                            renderer.print_info(&format!("top_k set to {value}"));
+                        }
+                        ChatCommand::ClearTopK => {
+                            session.set_top_k(None);
+                            renderer.print_info("top_k reset to model default");
+                        }
+                        ChatCommand::AddStopSequence(sequence) => {
+                            session.add_stop_sequence(sequence.clone());
+                            renderer.print_info(&format!("Added stop sequence: {sequence}"));
+                        }
+                        ChatCommand::ClearStopSequences => {
+                            session.clear_stop_sequences();
+                            renderer.print_info("Stop sequences cleared.");
+                        }
+                        ChatCommand::ListStopSequences => {
+                            print_stop_sequences(session.stop_sequences());
+                        }
+                        ChatCommand::Thinking(show) => {
+                            session.set_show_thinking(show);
+                            if show {
+                                renderer.print_info("Thinking output enabled.");
+                            } else {
+                                renderer.print_info("Thinking output hidden.");
+                            }
+                        }
+                        ChatCommand::Budget(tokens) => {
+                            session.set_session_budget(Some(tokens));
+                            renderer.print_info(&format!("Session budget set to {tokens} tokens."));
+                        }
+                        ChatCommand::ClearBudget => {
+                            session.set_session_budget(None);
+                            renderer.print_info("Session budget cleared.");
+                        }
+                        ChatCommand::TranscriptPath(path) => {
+                            session.set_transcript_path(Some(PathBuf::from(&path)));
+                            renderer.print_info(&format!("Transcript auto-save set to {}", path));
+                        }
+                        ChatCommand::ClearTranscriptPath => {
+                            session.set_transcript_path(None);
+                            renderer.print_info("Transcript auto-save disabled.");
+                        }
+                        ChatCommand::SaveTranscript(path) => {
+                            match session.save_transcript_to(&path) {
+                                Ok(_) => {
+                                    renderer.print_info(&format!("Transcript saved to {}", path))
+                                }
+                                Err(err) => renderer
+                                    .print_error(&format!("Failed to save transcript: {}", err)),
+                            }
+                        }
+                        ChatCommand::LoadTranscript(path) => {
+                            match session.load_transcript_from(&path) {
+                                Ok(_) => {
+                                    renderer.print_info(&format!("Transcript loaded from {}", path))
+                                }
+                                Err(err) => renderer
+                                    .print_error(&format!("Failed to load transcript: {}", err)),
+                            }
+                        }
+                        ChatCommand::Stats => {
+                            print_stats(&session);
+                        }
+                        ChatCommand::ShowConfig => {
+                            print_config(&session);
+                        }
+                        ChatCommand::Invalid(message) => {
+                            renderer.print_error(&message);
+                        }
+                    }
+                    continue;
+                }
+
+                // Regular message - send to API
+                println!("Claude:");
+                if let Err(e) = session
+                    .send_streaming(line, &mut renderer, interrupted.clone())
+                    .await
+                {
+                    renderer.print_error(&e.to_string());
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl+C at prompt - soft interrupt
+                println!();
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                // Ctrl+D - exit
+                println!("\nGoodbye!");
+                break;
+            }
+            Err(err) => {
+                renderer.print_error(&format!("Input error: {}", err));
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_stats(session: &ChatSession) {
+    let stats = session.stats();
+    println!("    Session Statistics:");
+    println!("      Model: {}", stats.model);
+    println!("      Messages: {}", stats.message_count);
+    println!("      Max tokens: {}", stats.max_tokens);
+    println!("      Temperature: {}", describe_float(stats.temperature));
+    println!("      Top-p: {}", describe_float(stats.top_p));
+    println!("      Top-k: {}", describe_top_k(stats.top_k));
+    if let Some(prompt) = stats.system_prompt.as_deref() {
+        println!("      System prompt: {}", prompt);
+    } else {
+        println!("      System prompt: (none)");
+    }
+    println!(
+        "      Thinking output: {}",
+        if stats.show_thinking {
+            "shown"
+        } else {
+            "hidden"
+        }
+    );
+    print_stop_sequences(&stats.stop_sequences);
+    println!(
+        "      Total tokens: {} in / {} out ({} requests)",
+        stats.total_input_tokens, stats.total_output_tokens, stats.total_requests
+    );
+    if let Some(input) = stats.last_turn_input_tokens {
+        let output = stats.last_turn_output_tokens.unwrap_or(0);
+        println!("      Last turn tokens: {input} in / {output} out");
+    }
+    if let Some(limit) = stats.session_budget_tokens {
+        let remaining = limit.saturating_sub(stats.budget_spent_tokens);
+        println!(
+            "      Budget: {}/{} tokens ({} remaining)",
+            stats.budget_spent_tokens, limit, remaining
+        );
+    } else {
+        println!("      Budget: (not set)");
+    }
+    match stats.transcript_path {
+        Some(ref path) => println!("      Transcript file: {}", path.display()),
+        None => println!("      Transcript file: (disabled)"),
+    }
+}
+
+fn print_config(session: &ChatSession) {
+    let stats = session.stats();
+    println!("    Current Configuration:");
+    println!("      Model: {}", stats.model);
+    println!("      Max tokens: {}", stats.max_tokens);
+    println!("      Temperature: {}", describe_float(stats.temperature));
+    println!("      Top-p: {}", describe_float(stats.top_p));
+    println!("      Top-k: {}", describe_top_k(stats.top_k));
+    println!(
+        "      Thinking output: {}",
+        if stats.show_thinking {
+            "shown"
+        } else {
+            "hidden"
+        }
+    );
+    if let Some(prompt) = stats.system_prompt.as_deref() {
+        println!("      System prompt: {}", prompt);
+    } else {
+        println!("      System prompt: (none)");
+    }
+    print_stop_sequences(&stats.stop_sequences);
+    match stats.transcript_path {
+        Some(ref path) => println!("      Transcript file: {}", path.display()),
+        None => println!("      Transcript file: (disabled)"),
+    }
+}
+
+fn print_stop_sequences(stop_sequences: &[String]) {
+    if stop_sequences.is_empty() {
+        println!("      Stop sequences: (none)");
+    } else {
+        println!("      Stop sequences:");
+        for seq in stop_sequences {
+            println!("        - {}", seq);
+        }
+    }
+}
+
+fn describe_float(value: Option<f32>) -> String {
+    value
+        .map(|v| format!("{v:.2}"))
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn describe_top_k(value: Option<u32>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "default".to_string())
+}

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -1,0 +1,412 @@
+//! Slash command parsing for the chat application.
+//!
+//! This module handles parsing of special commands that start with `/`,
+//! allowing users to control the chat session without sending messages
+//! to the API.
+
+/// A parsed chat command.
+///
+/// These commands control the chat session and are not sent to the API.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChatCommand {
+    /// Clear the conversation history.
+    Clear,
+
+    /// Change the model.
+    Model(String),
+
+    /// Set or clear the system prompt.
+    /// `None` clears the current system prompt.
+    System(Option<String>),
+
+    /// Set the maximum tokens per response.
+    MaxTokens(u32),
+
+    /// Set the sampling temperature.
+    Temperature(f32),
+
+    /// Clear the sampling temperature (use model default).
+    ClearTemperature,
+
+    /// Set the top-p value.
+    TopP(f32),
+
+    /// Clear the top-p value.
+    ClearTopP,
+
+    /// Set the top-k value.
+    TopK(u32),
+
+    /// Clear the top-k value.
+    ClearTopK,
+
+    /// Add a stop sequence.
+    AddStopSequence(String),
+
+    /// Clear all stop sequences.
+    ClearStopSequences,
+
+    /// List stop sequences.
+    ListStopSequences,
+
+    /// Toggle thinking visibility.
+    Thinking(bool),
+
+    /// Set a per-session token budget.
+    Budget(u64),
+
+    /// Clear the token budget.
+    ClearBudget,
+
+    /// Set the auto-save transcript path.
+    TranscriptPath(String),
+
+    /// Clear the auto-save transcript path.
+    ClearTranscriptPath,
+
+    /// Save the transcript to a specific file immediately.
+    SaveTranscript(String),
+
+    /// Load conversation history from a file.
+    LoadTranscript(String),
+
+    /// Display help information.
+    Help,
+
+    /// Exit the chat application.
+    Quit,
+
+    /// Display session statistics (message count, current model, etc.).
+    Stats,
+
+    /// Show the current configuration.
+    ShowConfig,
+
+    /// Report a parsing error back to the caller.
+    Invalid(String),
+}
+
+/// Parses user input for slash commands.
+///
+/// Returns `Some(ChatCommand)` if the input is a valid command,
+/// or `None` if it should be treated as a regular message.
+///
+/// # Examples
+///
+/// ```
+/// # use claudius::chat::parse_command;
+/// assert!(parse_command("/quit").is_some());
+/// assert!(parse_command("/model claude-sonnet-4-0").is_some());
+/// assert!(parse_command("Hello, Claude!").is_none());
+/// ```
+pub fn parse_command(input: &str) -> Option<ChatCommand> {
+    let input = input.trim();
+
+    if !input.starts_with('/') {
+        return None;
+    }
+
+    let mut parts = input[1..].splitn(2, ' ');
+    let command = parts.next()?.to_lowercase();
+    let argument = parts.next().map(|s| s.trim()).filter(|s| !s.is_empty());
+
+    let result = match command.as_str() {
+        "clear" => ChatCommand::Clear,
+        "model" => match argument {
+            Some(model) => ChatCommand::Model(model.to_string()),
+            None => ChatCommand::Invalid("/model requires a model name".to_string()),
+        },
+        "system" => ChatCommand::System(argument.map(|s| s.to_string())),
+        "help" | "?" => ChatCommand::Help,
+        "quit" | "exit" | "q" => ChatCommand::Quit,
+        "stats" | "status" => ChatCommand::Stats,
+        "config" => ChatCommand::ShowConfig,
+        "max_tokens" => parse_u32_command(argument, ChatCommand::MaxTokens, "/max_tokens"),
+        "temperature" => match argument {
+            Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearTemperature,
+            Some(arg) => match parse_f32_in_range(arg, 0.0, 1.0) {
+                Ok(value) => ChatCommand::Temperature(value),
+                Err(err) => ChatCommand::Invalid(format!("/temperature {err}")),
+            },
+            None => ChatCommand::Invalid("/temperature requires a value".to_string()),
+        },
+        "top_p" => match argument {
+            Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearTopP,
+            Some(arg) => match parse_f32_in_range(arg, 0.0, 1.0) {
+                Ok(value) => ChatCommand::TopP(value),
+                Err(err) => ChatCommand::Invalid(format!("/top_p {err}")),
+            },
+            None => ChatCommand::Invalid("/top_p requires a value".to_string()),
+        },
+        "top_k" => match argument {
+            Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearTopK,
+            Some(arg) => match arg.parse::<u32>() {
+                Ok(value) => ChatCommand::TopK(value),
+                Err(_) => ChatCommand::Invalid("/top_k expects a positive integer".to_string()),
+            },
+            None => ChatCommand::Invalid("/top_k requires a value".to_string()),
+        },
+        "stop" => parse_stop_command(argument),
+        "thinking" => match argument.and_then(parse_on_off) {
+            Some(value) => ChatCommand::Thinking(value),
+            None => ChatCommand::Invalid("/thinking expects 'on' or 'off'".to_string()),
+        },
+        "budget" => match argument {
+            Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearBudget,
+            Some(arg) => match arg.parse::<u64>() {
+                Ok(value) => ChatCommand::Budget(value),
+                Err(_) => {
+                    ChatCommand::Invalid("/budget expects an integer token count".to_string())
+                }
+            },
+            None => ChatCommand::Invalid("/budget requires a value".to_string()),
+        },
+        "transcript" => match argument {
+            Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearTranscriptPath,
+            Some(arg) => ChatCommand::TranscriptPath(arg.to_string()),
+            None => ChatCommand::Invalid("/transcript requires a file path".to_string()),
+        },
+        "save" => match argument {
+            Some(arg) => ChatCommand::SaveTranscript(arg.to_string()),
+            None => ChatCommand::Invalid("/save requires a file path".to_string()),
+        },
+        "load" => match argument {
+            Some(arg) => ChatCommand::LoadTranscript(arg.to_string()),
+            None => ChatCommand::Invalid("/load requires a file path".to_string()),
+        },
+        _ => ChatCommand::Invalid(format!("Unknown command: /{}", command)),
+    };
+
+    Some(result)
+}
+
+fn parse_stop_command(argument: Option<&str>) -> ChatCommand {
+    let Some(arg) = argument else {
+        return ChatCommand::Invalid(
+            "/stop requires 'add <sequence>', 'clear', or 'list'".to_string(),
+        );
+    };
+
+    let mut parts = arg.splitn(2, ' ');
+    let action = parts.next().unwrap();
+    match action.to_lowercase().as_str() {
+        "add" => {
+            let Some(sequence) = parts.next().map(|s| s.trim()).filter(|s| !s.is_empty()) else {
+                return ChatCommand::Invalid("/stop add requires a sequence".to_string());
+            };
+            ChatCommand::AddStopSequence(sequence.to_string())
+        }
+        "clear" => ChatCommand::ClearStopSequences,
+        "list" => ChatCommand::ListStopSequences,
+        _ => {
+            ChatCommand::Invalid("Unrecognized /stop action (use add, clear, or list)".to_string())
+        }
+    }
+}
+
+fn parse_u32_command<F>(argument: Option<&str>, constructor: F, name: &str) -> ChatCommand
+where
+    F: Fn(u32) -> ChatCommand,
+{
+    match argument {
+        Some(arg) => match arg.parse::<u32>() {
+            Ok(value) => constructor(value),
+            Err(_) => ChatCommand::Invalid(format!("{} expects a positive integer", name)),
+        },
+        None => ChatCommand::Invalid(format!("{} requires a value", name)),
+    }
+}
+
+fn parse_f32_in_range(value: &str, min: f32, max: f32) -> Result<f32, String> {
+    let parsed: f32 = value
+        .parse()
+        .map_err(|_| format!("expects a value between {min} and {max}"))?;
+    if parsed.is_finite() && parsed >= min && parsed <= max {
+        Ok(parsed)
+    } else {
+        Err(format!("expects a value between {min} and {max}"))
+    }
+}
+
+fn parse_on_off(value: &str) -> Option<bool> {
+    match value.to_lowercase().as_str() {
+        "on" | "true" | "yes" => Some(true),
+        "off" | "false" | "no" => Some(false),
+        _ => None,
+    }
+}
+
+/// Returns help text describing available commands.
+pub fn help_text() -> &'static str {
+    r#"Available commands:
+  /clear                 Clear conversation history
+  /model <name>          Change the model (e.g., /model claude-sonnet-4-0)
+  /system [prompt]       Set system prompt (no argument clears it)
+  /max_tokens <n>        Set maximum response tokens
+  /temperature <v>       Set temperature 0.0-1.0 (use 'clear' to reset)
+  /top_p <v>             Set top-p 0.0-1.0 (use 'clear' to reset)
+  /top_k <n>             Set top-k (use 'clear' to reset)
+  /stop add <seq>        Add a stop sequence
+  /stop clear            Clear all stop sequences
+  /stop list             List current stop sequences
+  /thinking on|off       Show or hide thinking blocks
+  /budget <tokens>       Set total session budget (or 'clear')
+  /transcript <file>     Enable auto-saving transcripts (or 'clear')
+  /save <file>           Save the current transcript immediately
+  /load <file>           Load a transcript from disk
+  /stats                 Show session statistics
+  /config                Show current configuration
+  /help                  Show this help message
+  /quit                  Exit the chat"#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_quit_commands() {
+        assert_eq!(parse_command("/quit"), Some(ChatCommand::Quit));
+        assert_eq!(parse_command("/exit"), Some(ChatCommand::Quit));
+        assert_eq!(parse_command("/q"), Some(ChatCommand::Quit));
+        assert_eq!(parse_command("  /quit  "), Some(ChatCommand::Quit));
+    }
+
+    #[test]
+    fn parse_clear() {
+        assert_eq!(parse_command("/clear"), Some(ChatCommand::Clear));
+        assert_eq!(parse_command("/CLEAR"), Some(ChatCommand::Clear));
+    }
+
+    #[test]
+    fn parse_model() {
+        assert_eq!(
+            parse_command("/model claude-sonnet-4-0"),
+            Some(ChatCommand::Model("claude-sonnet-4-0".to_string()))
+        );
+        assert_eq!(
+            parse_command("/model   claude-haiku-4-5  "),
+            Some(ChatCommand::Model("claude-haiku-4-5".to_string()))
+        );
+        assert_eq!(
+            parse_command("/model"),
+            Some(ChatCommand::Invalid(
+                "/model requires a model name".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_system() {
+        assert_eq!(
+            parse_command("/system You are a helpful assistant"),
+            Some(ChatCommand::System(Some(
+                "You are a helpful assistant".to_string()
+            )))
+        );
+        assert_eq!(parse_command("/system"), Some(ChatCommand::System(None)));
+    }
+
+    #[test]
+    fn parse_temperature() {
+        assert_eq!(
+            parse_command("/temperature 0.5"),
+            Some(ChatCommand::Temperature(0.5))
+        );
+        assert_eq!(
+            parse_command("/temperature clear"),
+            Some(ChatCommand::ClearTemperature)
+        );
+        assert!(matches!(
+            parse_command("/temperature"),
+            Some(ChatCommand::Invalid(msg)) if msg.contains("requires")
+        ));
+    }
+
+    #[test]
+    fn parse_stop_commands() {
+        assert_eq!(
+            parse_command("/stop add END"),
+            Some(ChatCommand::AddStopSequence("END".to_string()))
+        );
+        assert_eq!(
+            parse_command("/stop clear"),
+            Some(ChatCommand::ClearStopSequences)
+        );
+        assert_eq!(
+            parse_command("/stop list"),
+            Some(ChatCommand::ListStopSequences)
+        );
+    }
+
+    #[test]
+    fn parse_thinking_toggle() {
+        assert_eq!(
+            parse_command("/thinking on"),
+            Some(ChatCommand::Thinking(true))
+        );
+        assert_eq!(
+            parse_command("/thinking off"),
+            Some(ChatCommand::Thinking(false))
+        );
+        assert!(matches!(
+            parse_command("/thinking maybe"),
+            Some(ChatCommand::Invalid(msg)) if msg.contains("expects")
+        ));
+    }
+
+    #[test]
+    fn parse_budget() {
+        assert_eq!(
+            parse_command("/budget 1000"),
+            Some(ChatCommand::Budget(1000))
+        );
+        assert_eq!(
+            parse_command("/budget clear"),
+            Some(ChatCommand::ClearBudget)
+        );
+    }
+
+    #[test]
+    fn parse_transcript_commands() {
+        assert_eq!(
+            parse_command("/transcript chat.json"),
+            Some(ChatCommand::TranscriptPath("chat.json".to_string()))
+        );
+        assert_eq!(
+            parse_command("/transcript clear"),
+            Some(ChatCommand::ClearTranscriptPath)
+        );
+        assert_eq!(
+            parse_command("/save session.json"),
+            Some(ChatCommand::SaveTranscript("session.json".to_string()))
+        );
+        assert_eq!(
+            parse_command("/load session.json"),
+            Some(ChatCommand::LoadTranscript("session.json".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_stats_and_config() {
+        assert_eq!(parse_command("/stats"), Some(ChatCommand::Stats));
+        assert_eq!(parse_command("/config"), Some(ChatCommand::ShowConfig));
+    }
+
+    #[test]
+    fn non_commands() {
+        assert_eq!(parse_command("Hello, Claude!"), None);
+        assert_eq!(parse_command(""), None);
+        assert_eq!(parse_command("  "), None);
+    }
+
+    #[test]
+    fn help_text_not_empty() {
+        let help = help_text();
+        assert!(!help.is_empty());
+        assert!(help.contains("/quit"));
+        assert!(help.contains("/clear"));
+        assert!(help.contains("/model"));
+        assert!(help.contains("/temperature"));
+    }
+}

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -1,0 +1,263 @@
+//! Configuration types for the chat application.
+//!
+//! This module provides CLI argument parsing via `arrrg` and configuration
+//! structures for controlling chat behavior.
+
+use std::path::PathBuf;
+
+use arrrg_derive::CommandLine;
+
+use crate::types::{KnownModel, Model};
+
+/// Default maximum tokens per response.
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// Command-line arguments for the claudius-chat tool.
+#[derive(CommandLine, Debug, Default, PartialEq, Eq)]
+pub struct ChatArgs {
+    /// Model to use for chat.
+    #[arrrg(optional, "Model to use (default: claude-haiku-4-5)", "MODEL")]
+    pub model: Option<String>,
+
+    /// System prompt to set context for the conversation.
+    #[arrrg(optional, "System prompt for the conversation", "PROMPT")]
+    pub system: Option<String>,
+
+    /// Maximum tokens per response.
+    #[arrrg(optional, "Max tokens per response (default: 4096)", "TOKENS")]
+    pub max_tokens: Option<u32>,
+
+    /// Disable ANSI colors and styles.
+    #[arrrg(flag, "Disable ANSI colors/styles")]
+    pub no_color: bool,
+}
+
+/// Configuration for a chat session.
+///
+/// This struct holds the resolved configuration values after processing
+/// command-line arguments with appropriate defaults.
+#[derive(Debug, Clone)]
+pub struct ChatConfig {
+    /// The model to use for generating responses.
+    pub model: Model,
+
+    /// Optional system prompt to set conversation context.
+    pub system_prompt: Option<String>,
+
+    /// Maximum tokens per response.
+    pub max_tokens: u32,
+
+    /// Whether to use ANSI colors and styles in output.
+    pub use_color: bool,
+
+    /// Optional sampling temperature.
+    pub temperature: Option<f32>,
+
+    /// Optional top-p nucleus sampling value.
+    pub top_p: Option<f32>,
+
+    /// Optional top-k sampling limit.
+    pub top_k: Option<u32>,
+
+    /// Custom stop sequences supplied on every request.
+    pub stop_sequences: Vec<String>,
+
+    /// Whether thinking blocks should be rendered.
+    pub show_thinking: bool,
+
+    /// Optional per-session token budget (input + output).
+    pub session_budget_tokens: Option<u64>,
+
+    /// Path to persist transcripts automatically after each assistant turn.
+    pub transcript_path: Option<PathBuf>,
+}
+
+impl ChatConfig {
+    /// Creates a new ChatConfig with default values.
+    ///
+    /// Defaults:
+    /// - Model: claude-haiku-4-5
+    /// - Max tokens: 4096
+    /// - Color: enabled
+    /// - Thinking: shown
+    pub fn new() -> Self {
+        Self {
+            model: Model::Known(KnownModel::ClaudeHaiku45),
+            system_prompt: None,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            use_color: true,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: Vec::new(),
+            show_thinking: true,
+            session_budget_tokens: None,
+            transcript_path: None,
+        }
+    }
+
+    /// Sets the model to use.
+    pub fn with_model(mut self, model: Model) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// Sets the system prompt.
+    pub fn with_system_prompt(mut self, prompt: String) -> Self {
+        self.system_prompt = Some(prompt);
+        self
+    }
+
+    /// Sets the maximum tokens per response.
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Disables ANSI color output.
+    pub fn without_color(mut self) -> Self {
+        self.use_color = false;
+        self
+    }
+
+    /// Sets the sampling temperature.
+    pub fn with_temperature(mut self, temperature: Option<f32>) -> Self {
+        self.temperature = temperature;
+        self
+    }
+
+    /// Sets the top-p value.
+    pub fn with_top_p(mut self, top_p: Option<f32>) -> Self {
+        self.top_p = top_p;
+        self
+    }
+
+    /// Sets the top-k value.
+    pub fn with_top_k(mut self, top_k: Option<u32>) -> Self {
+        self.top_k = top_k;
+        self
+    }
+
+    /// Sets the stop sequences.
+    pub fn with_stop_sequences(mut self, stop_sequences: Vec<String>) -> Self {
+        self.stop_sequences = stop_sequences;
+        self
+    }
+
+    /// Sets whether thinking blocks should be shown.
+    pub fn with_show_thinking(mut self, show_thinking: bool) -> Self {
+        self.show_thinking = show_thinking;
+        self
+    }
+
+    /// Sets the session token budget.
+    pub fn with_session_budget(mut self, budget: Option<u64>) -> Self {
+        self.session_budget_tokens = budget;
+        self
+    }
+
+    /// Sets the transcript auto-save path.
+    pub fn with_transcript_path(mut self, path: Option<PathBuf>) -> Self {
+        self.transcript_path = path;
+        self
+    }
+}
+
+impl Default for ChatConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<ChatArgs> for ChatConfig {
+    fn from(args: ChatArgs) -> Self {
+        let model = args
+            .model
+            .map(|s| s.parse::<Model>().unwrap_or(Model::Custom(s)))
+            .unwrap_or(Model::Known(KnownModel::ClaudeHaiku45));
+
+        ChatConfig {
+            model,
+            system_prompt: args.system,
+            max_tokens: args.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            use_color: !args.no_color,
+            ..ChatConfig::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = ChatConfig::new();
+        assert_eq!(config.model, Model::Known(KnownModel::ClaudeHaiku45));
+        assert_eq!(config.max_tokens, 4096);
+        assert!(config.use_color);
+        assert!(config.system_prompt.is_none());
+        assert!(config.temperature.is_none());
+        assert!(config.top_p.is_none());
+        assert!(config.top_k.is_none());
+        assert!(config.stop_sequences.is_empty());
+        assert!(config.session_budget_tokens.is_none());
+        assert!(config.transcript_path.is_none());
+    }
+
+    #[test]
+    fn config_from_args_defaults() {
+        let args = ChatArgs::default();
+        let config = ChatConfig::from(args);
+        assert_eq!(config.model, Model::Known(KnownModel::ClaudeHaiku45));
+        assert_eq!(config.max_tokens, 4096);
+        assert!(config.use_color);
+        assert!(config.show_thinking);
+    }
+
+    #[test]
+    fn config_from_args_custom() {
+        let args = ChatArgs {
+            model: Some("claude-sonnet-4-0".to_string()),
+            system: Some("You are helpful.".to_string()),
+            max_tokens: Some(8192),
+            no_color: true,
+        };
+        let config = ChatConfig::from(args);
+        assert_eq!(config.model, Model::Known(KnownModel::ClaudeSonnet40));
+        assert_eq!(config.system_prompt, Some("You are helpful.".to_string()));
+        assert_eq!(config.max_tokens, 8192);
+        assert!(!config.use_color);
+    }
+
+    #[test]
+    fn config_builder_pattern() {
+        let config = ChatConfig::new()
+            .with_model(Model::Known(KnownModel::ClaudeSonnet40))
+            .with_system_prompt("Test prompt".to_string())
+            .with_max_tokens(2048)
+            .without_color()
+            .with_temperature(Some(0.6))
+            .with_top_p(Some(0.9))
+            .with_top_k(Some(64))
+            .with_stop_sequences(vec!["END".to_string()])
+            .with_show_thinking(false)
+            .with_session_budget(Some(10_000))
+            .with_transcript_path(Some(PathBuf::from("transcript.json")));
+
+        assert_eq!(config.model, Model::Known(KnownModel::ClaudeSonnet40));
+        assert_eq!(config.system_prompt, Some("Test prompt".to_string()));
+        assert_eq!(config.max_tokens, 2048);
+        assert!(!config.use_color);
+        assert_eq!(config.temperature, Some(0.6));
+        assert_eq!(config.top_p, Some(0.9));
+        assert_eq!(config.top_k, Some(64));
+        assert_eq!(config.stop_sequences, vec!["END".to_string()]);
+        assert!(!config.show_thinking);
+        assert_eq!(config.session_budget_tokens, Some(10_000));
+        assert_eq!(
+            config.transcript_path,
+            Some(PathBuf::from("transcript.json"))
+        );
+    }
+}

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1,0 +1,28 @@
+//! Chat application module for interactive conversations with Claude.
+//!
+//! This module provides a streaming REPL chat interface built on top of the
+//! claudius client library. It supports:
+//!
+//! - Streaming responses with real-time token display
+//! - ANSI-styled output for thinking blocks
+//! - Slash commands for session control
+//! - Configurable model, system prompt, and parameters
+//!
+//! # Architecture
+//!
+//! The module is organized into several components:
+//!
+//! - [`config`]: CLI argument parsing and configuration
+//! - [`session`]: Core chat session management and API interaction
+//! - [`render`]: Output rendering with ANSI styling support
+//! - [`commands`]: Slash command parsing and handling
+
+mod commands;
+mod config;
+mod render;
+mod session;
+
+pub use commands::{ChatCommand, help_text, parse_command};
+pub use config::{ChatArgs, ChatConfig};
+pub use render::{PlainTextRenderer, Renderer};
+pub use session::{ChatSession, SessionStats};

--- a/src/chat/render.rs
+++ b/src/chat/render.rs
@@ -1,0 +1,278 @@
+//! Output rendering for the chat application.
+//!
+//! This module provides a trait-based rendering abstraction that allows
+//! for different output styles. The default implementation uses ANSI
+//! escape codes for styling thinking blocks differently from regular text.
+
+use std::io::{self, Stdout, Write};
+
+/// ANSI escape code for dim text (used for thinking blocks).
+const ANSI_DIM: &str = "\x1b[2m";
+
+/// ANSI escape code for italic text (used for thinking blocks).
+const ANSI_ITALIC: &str = "\x1b[3m";
+
+/// ANSI escape code to reset all styling.
+const ANSI_RESET: &str = "\x1b[0m";
+
+/// ANSI escape code for cyan text (used for tool names).
+const ANSI_CYAN: &str = "\x1b[36m";
+
+/// ANSI escape code for yellow text (used for tool input).
+const ANSI_YELLOW: &str = "\x1b[33m";
+
+/// ANSI escape code for green text (used for tool result success).
+const ANSI_GREEN: &str = "\x1b[32m";
+
+/// ANSI escape code for red text (used for tool result errors).
+const ANSI_RED: &str = "\x1b[31m";
+
+/// ANSI escape code for magenta text (used for tool result bodies).
+const ANSI_MAGENTA: &str = "\x1b[35m";
+
+/// Trait for rendering chat output.
+///
+/// This abstraction allows for different rendering strategies:
+/// - Plain text with ANSI styling
+/// - Plain text without styling (for piping/redirecting)
+/// - TUI rendering, tool call display for agents
+pub trait Renderer: Send {
+    /// Print a chunk of regular response text.
+    ///
+    /// This is called incrementally as tokens are streamed from the API.
+    fn print_text(&mut self, text: &str);
+
+    /// Print a chunk of thinking text.
+    ///
+    /// Thinking blocks are displayed differently (dim/italic) to
+    /// distinguish them from the main response.
+    fn print_thinking(&mut self, text: &str);
+
+    /// Print an error message.
+    fn print_error(&mut self, error: &str);
+
+    /// Print an informational message.
+    fn print_info(&mut self, info: &str);
+
+    /// Called when a tool use block starts.
+    ///
+    /// This is called when the model begins a tool call, before any
+    /// input JSON is streamed.
+    fn start_tool_use(&mut self, name: &str, id: &str);
+
+    /// Print a chunk of tool input JSON.
+    ///
+    /// This is called incrementally as the tool input JSON is streamed.
+    fn print_tool_input(&mut self, partial_json: &str);
+
+    /// Called when a tool use block is complete.
+    ///
+    /// This is called after all tool input JSON has been streamed.
+    fn finish_tool_use(&mut self);
+
+    /// Called when the model streams a tool result block.
+    fn start_tool_result(&mut self, tool_use_id: &str, is_error: bool);
+
+    /// Print tool result text content.
+    fn print_tool_result_text(&mut self, text: &str);
+
+    /// Called when a tool result block is complete.
+    fn finish_tool_result(&mut self);
+
+    /// Called when a response is complete.
+    ///
+    /// Used to ensure proper newlines and cleanup after streaming.
+    fn finish_response(&mut self);
+
+    /// Called when the stream is interrupted by the user.
+    fn print_interrupted(&mut self);
+}
+
+/// Plain text renderer with optional ANSI styling.
+///
+/// This renderer outputs text directly to stdout with optional
+/// ANSI escape codes for styling thinking blocks and tool use.
+pub struct PlainTextRenderer {
+    stdout: Stdout,
+    use_color: bool,
+    in_thinking: bool,
+    in_tool_use: bool,
+    in_tool_result: bool,
+}
+
+impl PlainTextRenderer {
+    /// Creates a new PlainTextRenderer with ANSI colors enabled.
+    pub fn new() -> Self {
+        Self {
+            stdout: io::stdout(),
+            use_color: true,
+            in_thinking: false,
+            in_tool_use: false,
+            in_tool_result: false,
+        }
+    }
+
+    /// Creates a new PlainTextRenderer with specified color setting.
+    pub fn with_color(use_color: bool) -> Self {
+        Self {
+            stdout: io::stdout(),
+            use_color,
+            in_thinking: false,
+            in_tool_use: false,
+            in_tool_result: false,
+        }
+    }
+
+    /// Flushes stdout to ensure immediate display of streamed content.
+    fn flush(&mut self) {
+        let _ = self.stdout.flush();
+    }
+
+    fn reset_thinking(&mut self) {
+        if self.in_thinking {
+            if self.use_color {
+                print!("{ANSI_RESET}");
+            }
+            self.in_thinking = false;
+        }
+    }
+
+    fn reset_tool_result(&mut self) {
+        if self.in_tool_result {
+            if self.use_color {
+                print!("{ANSI_RESET}");
+            }
+            self.in_tool_result = false;
+        }
+    }
+
+    fn reset_styles(&mut self) {
+        self.reset_thinking();
+        self.reset_tool_result();
+    }
+}
+
+impl Default for PlainTextRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Renderer for PlainTextRenderer {
+    fn print_text(&mut self, text: &str) {
+        self.reset_styles();
+        print!("{text}");
+        self.flush();
+    }
+
+    fn print_thinking(&mut self, text: &str) {
+        if self.use_color {
+            if !self.in_thinking {
+                print!("{ANSI_DIM}{ANSI_ITALIC}");
+                self.in_thinking = true;
+            }
+            print!("{text}");
+        } else {
+            if !self.in_thinking {
+                print!("\n[thinking] ");
+                self.in_thinking = true;
+            }
+            print!("{text}");
+        }
+        self.flush();
+    }
+
+    fn print_error(&mut self, error: &str) {
+        self.reset_styles();
+        eprintln!("\nError: {error}");
+    }
+
+    fn print_info(&mut self, info: &str) {
+        self.reset_styles();
+        println!("{info}");
+    }
+
+    fn start_tool_use(&mut self, name: &str, id: &str) {
+        self.reset_styles();
+        self.in_tool_use = true;
+
+        if self.use_color {
+            print!("\n{ANSI_CYAN}[tool: {name}]{ANSI_RESET} {ANSI_DIM}({id}){ANSI_RESET}\n");
+            print!("{ANSI_YELLOW}");
+        } else {
+            print!("\n[tool: {name}] ({id})\n");
+        }
+        self.flush();
+    }
+
+    fn print_tool_input(&mut self, partial_json: &str) {
+        print!("{partial_json}");
+        self.flush();
+    }
+
+    fn finish_tool_use(&mut self) {
+        if self.use_color {
+            print!("{ANSI_RESET}");
+        }
+        println!();
+        self.in_tool_use = false;
+        self.flush();
+    }
+
+    fn start_tool_result(&mut self, tool_use_id: &str, is_error: bool) {
+        self.reset_styles();
+        self.in_tool_result = true;
+        if self.use_color {
+            let label_color = if is_error { ANSI_RED } else { ANSI_GREEN };
+            let status = if is_error { "error" } else { "ok" };
+            print!(
+                "\n{label_color}[tool result: {tool_use_id} ({status})]{ANSI_RESET}\n{ANSI_MAGENTA}"
+            );
+        } else if is_error {
+            print!("\n[tool result: {tool_use_id} error]\n");
+        } else {
+            print!("\n[tool result: {tool_use_id}]\n");
+        }
+        self.flush();
+    }
+
+    fn print_tool_result_text(&mut self, text: &str) {
+        print!("{text}");
+        self.flush();
+    }
+
+    fn finish_tool_result(&mut self) {
+        self.reset_tool_result();
+        println!();
+        self.flush();
+    }
+
+    fn finish_response(&mut self) {
+        self.reset_styles();
+        println!();
+        self.flush();
+    }
+
+    fn print_interrupted(&mut self) {
+        self.reset_styles();
+        println!("\n[interrupted]");
+        self.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renderer_default_has_color() {
+        let renderer = PlainTextRenderer::new();
+        assert!(renderer.use_color);
+    }
+
+    #[test]
+    fn renderer_without_color() {
+        let renderer = PlainTextRenderer::with_color(false);
+        assert!(!renderer.use_color);
+    }
+}

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -1,0 +1,544 @@
+//! Core chat session management.
+//!
+//! This module provides the `ChatSession` struct which manages conversation
+//! state and handles streaming API interactions.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{from_reader, to_string_pretty, to_writer_pretty};
+use tokio::pin;
+
+use crate::Error;
+use crate::chat::config::ChatConfig;
+use crate::chat::render::Renderer;
+use crate::client::Anthropic;
+use crate::error::Result;
+use crate::types::{
+    ContentBlock, ContentBlockDelta, MessageCreateParams, MessageDeltaUsage, MessageParam,
+    MessageParamContent, MessageRole, MessageStreamEvent, Model, ToolResultBlockContent, Usage,
+};
+
+/// A chat session that manages conversation state and API interactions.
+///
+/// The session maintains message history and handles streaming responses
+/// from the Anthropic API.
+pub struct ChatSession {
+    client: Anthropic,
+    messages: Vec<MessageParam>,
+    config: ChatConfig,
+    usage_totals: Usage,
+    last_turn_usage: Option<Usage>,
+    request_count: u64,
+    budget_spent_tokens: u64,
+}
+
+/// Aggregated stats for a chat session.
+#[derive(Debug, Clone)]
+pub struct SessionStats {
+    /// The model used for the session.
+    pub model: Model,
+    /// The number of messages in the conversation.
+    pub message_count: usize,
+    /// The maximum tokens per response.
+    pub max_tokens: u32,
+    /// The system prompt, if any.
+    pub system_prompt: Option<String>,
+    /// The sampling temperature, if set.
+    pub temperature: Option<f32>,
+    /// The top-p value, if set.
+    pub top_p: Option<f32>,
+    /// The top-k value, if set.
+    pub top_k: Option<u32>,
+    /// The configured stop sequences.
+    pub stop_sequences: Vec<String>,
+    /// Whether thinking blocks are displayed.
+    pub show_thinking: bool,
+    /// The session token budget limit, if set.
+    pub session_budget_tokens: Option<u64>,
+    /// Total tokens spent against the budget.
+    pub budget_spent_tokens: u64,
+    /// The auto-save transcript path, if set.
+    pub transcript_path: Option<PathBuf>,
+    /// Total input tokens across all requests.
+    pub total_input_tokens: u64,
+    /// Total output tokens across all requests.
+    pub total_output_tokens: u64,
+    /// Total number of API requests made.
+    pub total_requests: u64,
+    /// Input tokens for the last turn, if available.
+    pub last_turn_input_tokens: Option<u64>,
+    /// Output tokens for the last turn, if available.
+    pub last_turn_output_tokens: Option<u64>,
+}
+
+impl ChatSession {
+    /// Creates a new chat session with the given client and configuration.
+    pub fn new(client: Anthropic, config: ChatConfig) -> Self {
+        Self {
+            client,
+            messages: Vec::new(),
+            config,
+            usage_totals: Usage::new(0, 0),
+            last_turn_usage: None,
+            request_count: 0,
+            budget_spent_tokens: 0,
+        }
+    }
+
+    /// Sends a user message and streams the response.
+    ///
+    /// This method:
+    /// 1. Adds the user message to history
+    /// 2. Sends a streaming request to the API
+    /// 3. Renders response chunks as they arrive
+    /// 4. Adds the complete assistant response to history
+    ///
+    /// The `interrupted` flag can be set to `true` to cancel the stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails.
+    pub async fn send_streaming(
+        &mut self,
+        user_input: &str,
+        renderer: &mut dyn Renderer,
+        interrupted: Arc<AtomicBool>,
+    ) -> Result<()> {
+        if let Some(limit) = self.config.session_budget_tokens
+            && self.budget_spent_tokens >= limit
+        {
+            renderer.print_error(
+                "Session budget exhausted. Use /budget to increase or clear the limit.",
+            );
+            return Err(Error::bad_request(
+                "session budget exhausted",
+                Some("budget".to_string()),
+            ));
+        }
+
+        // Add user message to history
+        self.messages.push(MessageParam {
+            role: MessageRole::User,
+            content: MessageParamContent::String(user_input.to_string()),
+        });
+
+        // Build request parameters
+        let mut params = MessageCreateParams::new(
+            self.config.max_tokens,
+            self.messages.clone(),
+            self.config.model.clone(),
+        )
+        .with_stream(true);
+
+        if let Some(ref system) = self.config.system_prompt {
+            params = params.with_system_string(system.clone());
+        }
+        if let Some(temp) = self.config.temperature {
+            params = params.with_temperature(temp)?;
+        }
+        if let Some(top_p) = self.config.top_p {
+            params = params.with_top_p(top_p)?;
+        }
+        if let Some(top_k) = self.config.top_k {
+            params = params.with_top_k(top_k);
+        }
+        if !self.config.stop_sequences.is_empty() {
+            params = params.with_stop_sequences(self.config.stop_sequences.clone());
+        }
+
+        let mut accumulated_text = String::new();
+        let mut was_interrupted = false;
+        let mut active_tool_uses: HashSet<usize> = HashSet::new();
+        let mut active_tool_results: HashSet<usize> = HashSet::new();
+        let mut turn_usage: Option<Usage> = None;
+
+        {
+            let stream = self.client.stream(params).await?;
+            pin!(stream);
+
+            // Process stream events
+            while let Some(event) = stream.next().await {
+                // Check for interrupt
+                if interrupted.load(Ordering::Relaxed) {
+                    was_interrupted = true;
+                    renderer.print_interrupted();
+                    break;
+                }
+
+                match event {
+                    Ok(event) => match &event {
+                        MessageStreamEvent::Ping | MessageStreamEvent::MessageStart(_) => {}
+                        MessageStreamEvent::MessageDelta(delta_event) => {
+                            turn_usage = Some(usage_from_delta(&delta_event.usage));
+                        }
+                        MessageStreamEvent::ContentBlockStart(start_event) => {
+                            match &start_event.content_block {
+                                ContentBlock::ToolUse(tool_use) => {
+                                    active_tool_uses.insert(start_event.index);
+                                    renderer.start_tool_use(&tool_use.name, &tool_use.id);
+                                }
+                                ContentBlock::ToolResult(tool_result) => {
+                                    active_tool_results.insert(start_event.index);
+                                    renderer.start_tool_result(
+                                        &tool_result.tool_use_id,
+                                        tool_result.is_error.unwrap_or(false),
+                                    );
+                                    if let Some(content) = &tool_result.content {
+                                        render_tool_result_content(renderer, content);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        MessageStreamEvent::ContentBlockDelta(delta_event) => {
+                            match &delta_event.delta {
+                                ContentBlockDelta::InputJsonDelta(json_delta) => {
+                                    if active_tool_uses.contains(&delta_event.index) {
+                                        renderer.print_tool_input(&json_delta.partial_json);
+                                    }
+                                }
+                                ContentBlockDelta::TextDelta(text_delta) => {
+                                    if active_tool_results.contains(&delta_event.index) {
+                                        renderer.print_tool_result_text(&text_delta.text);
+                                    } else {
+                                        renderer.print_text(&text_delta.text);
+                                        accumulated_text.push_str(&text_delta.text);
+                                    }
+                                }
+                                ContentBlockDelta::ThinkingDelta(thinking_delta) => {
+                                    if self.config.show_thinking {
+                                        renderer.print_thinking(&thinking_delta.thinking);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        MessageStreamEvent::ContentBlockStop(stop_event) => {
+                            if active_tool_uses.remove(&stop_event.index) {
+                                renderer.finish_tool_use();
+                            }
+                            if active_tool_results.remove(&stop_event.index) {
+                                renderer.finish_tool_result();
+                            }
+                        }
+                        MessageStreamEvent::MessageStop(_) => break,
+                    },
+                    Err(e) => {
+                        renderer.print_error(&e.to_string());
+                        // Remove the user message since the request failed
+                        self.messages.pop();
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        // Finish the response (newline, reset styling)
+        if !was_interrupted {
+            renderer.finish_response();
+        }
+
+        // Add assistant response to history (even if interrupted, include what we got)
+        if !accumulated_text.is_empty() {
+            self.messages.push(MessageParam {
+                role: MessageRole::Assistant,
+                content: MessageParamContent::String(accumulated_text),
+            });
+        } else if was_interrupted {
+            // If interrupted with no text, remove the user message
+            self.messages.pop();
+        }
+
+        if let Some(usage) = turn_usage {
+            self.record_usage(usage);
+        } else {
+            self.last_turn_usage = None;
+        }
+
+        self.auto_save_transcript()?;
+
+        Ok(())
+    }
+
+    /// Clears the conversation history.
+    pub fn clear(&mut self) {
+        self.messages.clear();
+    }
+
+    /// Returns the number of messages in the conversation.
+    pub fn message_count(&self) -> usize {
+        self.messages.len()
+    }
+
+    /// Changes the model used for responses.
+    pub fn set_model(&mut self, model: Model) {
+        self.config.model = model;
+    }
+
+    /// Returns the current model.
+    pub fn model(&self) -> &Model {
+        &self.config.model
+    }
+
+    /// Sets or clears the system prompt.
+    pub fn set_system_prompt(&mut self, prompt: Option<String>) {
+        self.config.system_prompt = prompt;
+    }
+
+    /// Returns the current system prompt, if any.
+    pub fn system_prompt(&self) -> Option<&str> {
+        self.config.system_prompt.as_deref()
+    }
+
+    /// Sets the maximum tokens per response.
+    pub fn set_max_tokens(&mut self, max_tokens: u32) {
+        self.config.max_tokens = max_tokens;
+    }
+
+    /// Sets the sampling temperature.
+    pub fn set_temperature(&mut self, temperature: Option<f32>) {
+        self.config.temperature = temperature;
+    }
+
+    /// Sets the top-p value.
+    pub fn set_top_p(&mut self, top_p: Option<f32>) {
+        self.config.top_p = top_p;
+    }
+
+    /// Sets the top-k value.
+    pub fn set_top_k(&mut self, top_k: Option<u32>) {
+        self.config.top_k = top_k;
+    }
+
+    /// Adds a stop sequence to the persistent list.
+    pub fn add_stop_sequence(&mut self, sequence: String) {
+        if !self
+            .config
+            .stop_sequences
+            .iter()
+            .any(|existing| existing == &sequence)
+        {
+            self.config.stop_sequences.push(sequence);
+        }
+    }
+
+    /// Clears all stop sequences.
+    pub fn clear_stop_sequences(&mut self) {
+        self.config.stop_sequences.clear();
+    }
+
+    /// Returns the configured stop sequences.
+    pub fn stop_sequences(&self) -> &[String] {
+        &self.config.stop_sequences
+    }
+
+    /// Controls whether thinking blocks are rendered.
+    pub fn set_show_thinking(&mut self, show: bool) {
+        self.config.show_thinking = show;
+    }
+
+    /// Returns whether thinking blocks are rendered.
+    pub fn show_thinking(&self) -> bool {
+        self.config.show_thinking
+    }
+
+    /// Sets the session token budget.
+    pub fn set_session_budget(&mut self, budget: Option<u64>) {
+        self.config.session_budget_tokens = budget;
+    }
+
+    /// Returns the remaining session budget, if any.
+    pub fn session_budget_remaining(&self) -> Option<i64> {
+        self.config.session_budget_tokens.map(|limit| {
+            let spent = self.budget_spent_tokens as i64;
+            limit as i64 - spent
+        })
+    }
+
+    /// Sets the auto-save transcript path.
+    pub fn set_transcript_path(&mut self, path: Option<PathBuf>) {
+        self.config.transcript_path = path;
+    }
+
+    /// Returns the configured transcript path, if any.
+    pub fn transcript_path(&self) -> Option<&Path> {
+        self.config.transcript_path.as_deref()
+    }
+
+    /// Saves the transcript to the specified path.
+    pub fn save_transcript_to<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let transcript = TranscriptFile::new(&self.messages);
+        let file = File::create(path.as_ref())
+            .map_err(|err| Error::io("failed to create transcript file", err))?;
+        let writer = BufWriter::new(file);
+        to_writer_pretty(writer, &transcript).map_err(|err| {
+            Error::serialization("failed to serialize transcript", Some(Box::new(err)))
+        })
+    }
+
+    /// Loads a transcript from disk, replacing the current conversation history.
+    pub fn load_transcript_from<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        let file = File::open(path.as_ref())
+            .map_err(|err| Error::io("failed to open transcript file", err))?;
+        let reader = BufReader::new(file);
+        let transcript: TranscriptFile = from_reader(reader).map_err(|err| {
+            Error::serialization("failed to parse transcript", Some(Box::new(err)))
+        })?;
+        self.messages = transcript.messages;
+        Ok(())
+    }
+
+    /// Returns the current session statistics snapshot.
+    pub fn stats(&self) -> SessionStats {
+        SessionStats {
+            model: self.config.model.clone(),
+            message_count: self.message_count(),
+            max_tokens: self.config.max_tokens,
+            system_prompt: self.config.system_prompt.clone(),
+            temperature: self.config.temperature,
+            top_p: self.config.top_p,
+            top_k: self.config.top_k,
+            stop_sequences: self.config.stop_sequences.clone(),
+            show_thinking: self.config.show_thinking,
+            session_budget_tokens: self.config.session_budget_tokens,
+            budget_spent_tokens: self.budget_spent_tokens,
+            transcript_path: self.config.transcript_path.clone(),
+            total_input_tokens: tokens_to_u64(self.usage_totals.input_tokens),
+            total_output_tokens: tokens_to_u64(self.usage_totals.output_tokens),
+            total_requests: self.request_count,
+            last_turn_input_tokens: self
+                .last_turn_usage
+                .map(|usage| tokens_to_u64(usage.input_tokens)),
+            last_turn_output_tokens: self
+                .last_turn_usage
+                .map(|usage| tokens_to_u64(usage.output_tokens)),
+        }
+    }
+
+    fn record_usage(&mut self, usage: Usage) {
+        self.last_turn_usage = Some(usage);
+        self.usage_totals = self.usage_totals + usage;
+        self.request_count = self.request_count.saturating_add(1);
+        let turn_total = tokens_to_u64(usage.input_tokens) + tokens_to_u64(usage.output_tokens);
+        self.budget_spent_tokens = self.budget_spent_tokens.saturating_add(turn_total);
+    }
+
+    fn auto_save_transcript(&self) -> Result<()> {
+        if let Some(path) = &self.config.transcript_path {
+            self.save_transcript_to(path)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptFile {
+    version: u8,
+    messages: Vec<MessageParam>,
+}
+
+impl TranscriptFile {
+    fn new(messages: &[MessageParam]) -> Self {
+        Self {
+            version: 1,
+            messages: messages.to_vec(),
+        }
+    }
+}
+
+fn render_tool_result_content(renderer: &mut dyn Renderer, content: &ToolResultBlockContent) {
+    match content {
+        ToolResultBlockContent::String(text) => renderer.print_tool_result_text(text),
+        _ => match to_string_pretty(content) {
+            Ok(json) => renderer.print_tool_result_text(&json),
+            Err(_) => renderer.print_tool_result_text("<unrenderable tool result>"),
+        },
+    }
+}
+
+fn usage_from_delta(delta_usage: &MessageDeltaUsage) -> Usage {
+    let mut usage = Usage::new(
+        delta_usage.input_tokens.unwrap_or(0),
+        delta_usage.output_tokens,
+    );
+    if let Some(cache) = delta_usage.cache_creation_input_tokens {
+        usage = usage.with_cache_creation_input_tokens(cache);
+    }
+    if let Some(cache_read) = delta_usage.cache_read_input_tokens {
+        usage = usage.with_cache_read_input_tokens(cache_read);
+    }
+    if let Some(server_tool) = &delta_usage.server_tool_use {
+        usage = usage.with_server_tool_use(*server_tool);
+    }
+    usage
+}
+
+fn tokens_to_u64(value: i32) -> u64 {
+    value.max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::KnownModel;
+
+    #[test]
+    fn new_session_empty() {
+        let client = Anthropic::new(None).unwrap();
+        let config = ChatConfig::default();
+        let session = ChatSession::new(client, config);
+        assert_eq!(session.message_count(), 0);
+    }
+
+    #[test]
+    fn clear_session() {
+        let client = Anthropic::new(None).unwrap();
+        let config = ChatConfig::default();
+        let mut session = ChatSession::new(client, config);
+
+        // Manually add a message for testing
+        session.messages.push(MessageParam {
+            role: MessageRole::User,
+            content: MessageParamContent::String("test".to_string()),
+        });
+        assert_eq!(session.message_count(), 1);
+
+        session.clear();
+        assert_eq!(session.message_count(), 0);
+    }
+
+    #[test]
+    fn set_model() {
+        let client = Anthropic::new(None).unwrap();
+        let config = ChatConfig::default();
+        let mut session = ChatSession::new(client, config);
+
+        assert_eq!(session.model(), &Model::Known(KnownModel::ClaudeHaiku45));
+
+        session.set_model(Model::Known(KnownModel::ClaudeSonnet40));
+        assert_eq!(session.model(), &Model::Known(KnownModel::ClaudeSonnet40));
+    }
+
+    #[test]
+    fn set_system_prompt() {
+        let client = Anthropic::new(None).unwrap();
+        let config = ChatConfig::default();
+        let mut session = ChatSession::new(client, config);
+
+        assert!(session.system_prompt().is_none());
+
+        session.set_system_prompt(Some("Be helpful".to_string()));
+        assert_eq!(session.system_prompt(), Some("Be helpful"));
+
+        session.set_system_prompt(None);
+        assert!(session.system_prompt().is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 //! Anthropic's Claude AI models, including support for streaming responses, tool use,
 //! and agent-based interactions.
 
+pub mod chat;
+
 mod agent;
 mod backoff;
 mod client;


### PR DESCRIPTION
Add claudius-chat binary providing an interactive terminal interface for
conversing with Claude models via the Anthropic API.

Features:
- Streaming responses with real-time token display
- ANSI-styled output for thinking blocks and tool use
- Slash commands for session control (/model, /system, /stats, etc.)
- Configurable model, system prompt, and sampling parameters
- Token budget tracking with per-session limits
- Transcript persistence (auto-save and manual save/load)
- Ctrl+C interrupt handling for graceful stream cancellation

Architecture:
- chat/commands.rs: slash command parsing
- chat/config.rs: CLI argument parsing via arrrg
- chat/render.rs: trait-based output rendering with ANSI support
- chat/session.rs: conversation state and API interaction

Dependencies: rustyline for readline, ctrlc for signal handling.

Co-authored-by: AI
