### PR TITLE
refactor(client)!: require explicit stream flag in stream() method

### DIFF
--- a/examples/basic_chat.rs
+++ b/examples/basic_chat.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
         KnownModel::Claude37SonnetLatest,
     );
 
-    let stream = client.stream(params).await?;
+    let stream = client.stream(&params).await?;
 
     // Pin the stream so it can be polled
     pin!(stream);

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     )
     .with_system("You are Claude, an AI assistant made by Anthropic.");
 
-    let stream = client.stream(params).await?;
+    let stream = client.stream(&params).await?;
 
     // Pin the stream so it can be polled
     pin!(stream);

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -160,7 +160,7 @@ impl ChatSession {
         let mut turn_usage: Option<Usage> = None;
 
         {
-            let stream = self.client.stream(params).await?;
+            let stream = self.client.stream(&params).await?;
             pin!(stream);
 
             // Process stream events

--- a/src/client.rs
+++ b/src/client.rs
@@ -456,13 +456,18 @@ impl Anthropic {
     /// Returns a stream of MessageStreamEvent objects that can be processed incrementally.
     pub async fn stream(
         &self,
-        mut params: MessageCreateParams,
-    ) -> Result<impl Stream<Item = Result<MessageStreamEvent>>> {
+        params: &MessageCreateParams,
+    ) -> Result<impl Stream<Item = Result<MessageStreamEvent>> + use<>> {
         // Validate parameters first
         params.validate()?;
 
         // Ensure stream is enabled
-        params.stream = true;
+        if !params.stream {
+            return Err(Error::validation(
+                "stream must be true for streaming requests",
+                Some("stream".to_string()),
+            ));
+        }
 
         let response = self
             .retry_with_backoff(|| async {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -57,7 +57,7 @@ mod tests {
             Model::Known(KnownModel::Claude35HaikuLatest),
         );
 
-        let stream = client.stream(params).await;
+        let stream = client.stream(&params).await;
         assert!(stream.is_ok(), "Stream request should succeed");
     }
 
@@ -193,7 +193,7 @@ mod tests {
 
         let client = Anthropic::new(None).expect("Failed to create client with env API key");
 
-        let params = MessageCreateParams::new(
+        let params = MessageCreateParams::new_streaming(
             20,
             vec![MessageParam::new_with_string(
                 "Say 'streaming test passed' briefly".to_string(),
@@ -202,7 +202,7 @@ mod tests {
             Model::Known(KnownModel::Claude35HaikuLatest),
         );
 
-        let result = client.stream(params).await;
+        let result = client.stream(&params).await;
         assert!(
             result.is_ok(),
             "Streaming request should succeed with env API key"


### PR DESCRIPTION
Change stream() to take &MessageCreateParams instead of mut params:
- Callers must now set stream=true before calling, enforced via validation
- Return type uses `+ use<>` for proper lifetime handling
- More explicit API: streaming intent must be declared upfront

Update all call sites to pass params by reference and use
new_streaming() constructor where appropriate.

BREAKING CHANGE: stream() no longer auto-sets stream=true; callers must
use MessageCreateParams::new_streaming() or set stream=true explicitly.

Co-authored-by: AI
