### PR TITLE
fix(agent): enforce budget limits and serialize tool execution

### DIFF
--- a/examples/agentkb.rs
+++ b/examples/agentkb.rs
@@ -48,7 +48,7 @@ impl Agent for AgentKB {
 async fn main() {
     let client = Anthropic::new(None).unwrap();
     let mut agent = AgentKB::new("kb".into());
-    let budget = Arc::new(Budget::new_with_rates(100_000_000, 100, 500, 125, 10));
+    let budget = Arc::new(Budget::new_with_rates(25_000_000, 100, 500, 125, 10));
     let mut messages = vec![claudius::MessageParam {
         role: claudius::MessageRole::User,
         content: claudius::MessageParamContent::String(


### PR DESCRIPTION
Change tool result computation from parallel to sequential execution,
processing each tool one at a time in the order they appear.

Also fix budget enforcement by checking the return value of
consume_usage and returning an MaxTokens when the allocated budget is
exceeded, rather than silently continuing.

Co-authored-by: AI
