### PR TITLE
fix(render): add newline separator after thinking blocks

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -238,6 +238,9 @@ impl PlainTextRenderer {
             if self.use_color {
                 print!("{ANSI_RESET}");
             }
+            // Add newline separator when transitioning from thinking to other content.
+            println!();
+            self.line_start = true;
             self.in_thinking = false;
         }
     }


### PR DESCRIPTION
When transitioning from thinking mode to regular text output, the
thinking content would run directly into the response text without
visual separation. This made thinking blocks hard to distinguish from
the actual response.

Add a newline when resetting thinking mode to provide clear visual
separation between thinking content and the main response.

Co-authored-by: AI
