### PR TITLE
fix(chat): clear stale cache_control markers before reapplying

### DIFF
--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -291,7 +291,7 @@ fn print_stats<A: ChatAgent>(session: &ChatSession<A>) {
         "      Total tokens: {} in / {} out ({} requests)",
         stats.total_input_tokens, stats.total_output_tokens, stats.total_requests
     );
-    if stats.total_cache_creation_tokens > 0 || stats.total_cache_read_tokens > 0 {
+    if stats.caching_enabled {
         println!(
             "      Cache tokens: {} created / {} read",
             stats.total_cache_creation_tokens, stats.total_cache_read_tokens


### PR DESCRIPTION
As conversations grow, cache_control markers were accumulating on old
messages without being cleared. Since the API limits cache breakpoints
to 4 total (1 for system prompt + 3 for messages), exceeding this limit
could cause API errors.

Changes:
- Clear all existing cache_control markers before applying new ones
- Add clear_cache_control_from_message and clear_cache_control_on_block
  helpers to handle all content block types
- Update cache stats display to use caching_enabled flag instead of
  checking token counts (shows "0 created / 0 read" when enabled but
  no cache hits yet)
- Add test verifying old markers are cleared when new ones are applied
- Add test verifying cache tokens from message_start are preserved

Co-authored-by: AI
