### PR TITLE
feat(prompt): add structured output support to PromptTestConfig

### DIFF
--- a/prompts/structured_output_test.yaml
+++ b/prompts/structured_output_test.yaml
@@ -1,0 +1,40 @@
+name: "Structured Output Test"
+prompt: "Extract the following information from this text: John Smith is a 42-year-old software engineer from Seattle who speaks English and Spanish."
+system: "You are a helpful assistant that extracts structured information from text. Always respond with valid JSON matching the requested schema."
+model: "claude-haiku-4-5"
+max_tokens: 500
+temperature: 0.0
+output_format:
+  type: "json_schema"
+  schema:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+        description: "The person's full name"
+      age:
+        type: "integer"
+        description: "The person's age in years"
+      occupation:
+        type: "string"
+        description: "The person's job or profession"
+      location:
+        type: "string"
+        description: "The person's city or location"
+      languages:
+        type: "array"
+        items:
+          type: "string"
+        description: "Languages the person speaks"
+    required:
+      - "name"
+      - "age"
+      - "occupation"
+      - "location"
+      - "languages"
+    additionalProperties: false
+expected_contains:
+  - "John Smith"
+  - "42"
+  - "Seattle"
+  - "software engineer"


### PR DESCRIPTION
Add output_format field to PromptTestConfig enabling JSON schema constraints
for Claude's responses in prompt tests:

- Add output_format field with Option<OutputFormat> type
- Implement with_output_format() builder method with documentation
- Support YAML deserialization of output_format in test configs
- Integrate output_format in merge() for config inheritance
- Pass output_format to MessageCreateParams in execute()
- Add unit tests for builder and YAML round-trip serialization
- Include example prompt config (structured_output_test.yaml)

Co-authored-by: AI
