### PR TITLE
refactor(observability): accept Collector by reference

### DIFF
--- a/src/observability.rs
+++ b/src/observability.rs
@@ -23,7 +23,7 @@ pub(crate) static AGENT_TOOL_DURATION: Moments =
     Moments::new("claudius.agent.tool_duration_seconds");
 
 /// Register this crate's biometrics with the provided collector.
-pub fn register_biometrics(collector: Collector) {
+pub fn register_biometrics(collector: &Collector) {
     collector.register_counter(&CLIENT_REQUESTS);
     collector.register_counter(&CLIENT_REQUEST_ERRORS);
     collector.register_counter(&CLIENT_REQUEST_RETRIES);


### PR DESCRIPTION
Change register_biometrics to take &Collector instead of Collector,
avoiding unnecessary ownership transfer when registering metrics.

Co-authored-by: AI
