### PR TITLE
feat(client): add ClientLogger trait for API interaction logging

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,19 @@
+use std::env;
+use std::fs;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
 use futures::Stream;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client as ReqwestClient, Response, header};
 use serde::Deserialize;
-use std::env;
-use std::fs;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
+use crate::AccumulatingStream;
 use crate::backoff::ExponentialBackoff;
+use crate::client_logger::ClientLogger;
 use crate::error::{Error, Result};
 use crate::observability::{
     CLIENT_REQUEST_DURATION, CLIENT_REQUEST_ERRORS, CLIENT_REQUEST_RETRIES, CLIENT_REQUESTS,
@@ -19,6 +24,57 @@ use crate::types::{
     Message, MessageCountTokensParams, MessageCreateParams, MessageStreamEvent, MessageTokensCount,
     ModelInfo, ModelListParams, ModelListResponse,
 };
+
+/// A stream wrapper that logs events and the final message through a [`ClientLogger`].
+///
+/// This stream passes through all events from the underlying [`AccumulatingStream`],
+/// logging each event as it occurs and logging the final reconstructed message
+/// when the stream completes.
+pub struct LoggingStream<'a> {
+    inner: AccumulatingStream,
+    logger: &'a dyn ClientLogger,
+    receiver: Option<tokio::sync::oneshot::Receiver<Result<Message>>>,
+}
+
+impl<'a> LoggingStream<'a> {
+    /// Create a new logging stream wrapper.
+    fn new(
+        inner: AccumulatingStream,
+        receiver: tokio::sync::oneshot::Receiver<Result<Message>>,
+        logger: &'a dyn ClientLogger,
+    ) -> Self {
+        Self {
+            inner,
+            logger,
+            receiver: Some(receiver),
+        }
+    }
+}
+
+impl Stream for LoggingStream<'_> {
+    type Item = Result<MessageStreamEvent>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let inner = Pin::new(&mut self.inner);
+        match inner.poll_next(cx) {
+            Poll::Ready(Some(Ok(event))) => {
+                self.logger.log_stream_event(&event);
+                Poll::Ready(Some(Ok(event)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => {
+                // Stream ended - try to get the accumulated message
+                if let Some(mut receiver) = self.receiver.take()
+                    && let Ok(Ok(ref message)) = receiver.try_recv()
+                {
+                    self.logger.log_stream_message(message);
+                }
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
 
 const DEFAULT_API_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
@@ -485,6 +541,22 @@ impl Anthropic {
         result
     }
 
+    /// Send a message to the API with logging and get a non-streaming response.
+    ///
+    /// This method is identical to [`send`](Self::send) but additionally logs
+    /// the response through the provided [`ClientLogger`].
+    pub async fn send_with_logger(
+        &self,
+        params: MessageCreateParams,
+        logger: &dyn ClientLogger,
+    ) -> Result<Message> {
+        let result = self.send(params).await;
+        if let Ok(ref message) = result {
+            logger.log_response(message);
+        }
+        result
+    }
+
     /// Send a message to the API and get a streaming response.
     ///
     /// Returns a stream of MessageStreamEvent objects that can be processed incrementally.
@@ -563,6 +635,25 @@ impl Anthropic {
 
         // Create an SSE processor
         Ok(process_sse(stream))
+    }
+
+    /// Send a message to the API with logging and get a streaming response.
+    ///
+    /// This method is identical to [`stream`](Self::stream) but additionally logs
+    /// each streaming event and the final reconstructed message through the
+    /// provided [`ClientLogger`].
+    ///
+    /// Returns a [`LoggingStream`] that wraps an [`AccumulatingStream`], logging
+    /// each event as it passes through and logging the final message when the
+    /// stream completes.
+    pub async fn stream_with_logger<'a>(
+        &self,
+        params: &MessageCreateParams,
+        logger: &'a dyn ClientLogger,
+    ) -> Result<LoggingStream<'a>> {
+        let raw_stream = self.stream(params).await?;
+        let (accumulating_stream, receiver) = AccumulatingStream::new(raw_stream);
+        Ok(LoggingStream::new(accumulating_stream, receiver, logger))
     }
 
     /// Count tokens for a message.

--- a/src/client_logger.rs
+++ b/src/client_logger.rs
@@ -1,0 +1,60 @@
+//! Logging trait for Anthropic client operations.
+//!
+//! This module provides the [`ClientLogger`] trait that allows users to capture
+//! and log all API interactions passing through the [`Anthropic`] client.
+
+use crate::{Message, MessageStreamEvent};
+
+/// A trait for logging Anthropic client operations.
+///
+/// Implement this trait to capture and record all API interactions,
+/// including both non-streaming responses and individual streaming events.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use claudius::{ClientLogger, Message, MessageStreamEvent};
+/// use std::sync::Mutex;
+///
+/// struct FileLogger {
+///     file: Mutex<std::fs::File>,
+/// }
+///
+/// impl ClientLogger for FileLogger {
+///     fn log_response(&self, message: &Message) {
+///         let mut file = self.file.lock().unwrap();
+///         writeln!(file, "Response: {}", serde_json::to_string(message).unwrap()).unwrap();
+///     }
+///
+///     fn log_stream_event(&self, event: &MessageStreamEvent) {
+///         let mut file = self.file.lock().unwrap();
+///         writeln!(file, "Stream event: {}", serde_json::to_string(event).unwrap()).unwrap();
+///     }
+///
+///     fn log_stream_message(&self, message: &Message) {
+///         let mut file = self.file.lock().unwrap();
+///         writeln!(file, "Stream complete: {}", serde_json::to_string(message).unwrap()).unwrap();
+///     }
+/// }
+/// ```
+pub trait ClientLogger: Send + Sync {
+    /// Log a complete response from a non-streaming `send` call.
+    ///
+    /// This method is called once per successful `send` call with the full
+    /// [`Message`] response from the API.
+    fn log_response(&self, message: &Message);
+
+    /// Log an individual streaming event.
+    ///
+    /// This method is called for each [`MessageStreamEvent`] received during
+    /// a streaming request. Events include message starts, content deltas,
+    /// and message stops.
+    fn log_stream_event(&self, event: &MessageStreamEvent);
+
+    /// Log the reconstructed message from a completed stream.
+    ///
+    /// This method is called once when a stream completes successfully,
+    /// with the full [`Message`] that was reconstructed from all the
+    /// streaming events.
+    fn log_stream_message(&self, message: &Message);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod agent;
 mod backoff;
 mod cache_control;
 mod client;
+mod client_logger;
 mod error;
 mod json_schema;
 mod observability;
@@ -26,7 +27,8 @@ pub use agent::{
     Agent, Budget, FileSystem, IntermediateToolResult, Mount, MountHierarchy, TokenKind, Tool,
     ToolCallback, ToolResult, ToolSearchFileSystem, TurnOutcome, TurnStep,
 };
-pub use client::Anthropic;
+pub use client::{Anthropic, LoggingStream};
+pub use client_logger::ClientLogger;
 pub use error::{Error, Result};
 pub use json_schema::JsonSchema;
 pub use observability::register_biometrics;


### PR DESCRIPTION
Add a ClientLogger trait that allows users to capture and log all API
interactions passing through the Anthropic client:

- ClientLogger trait with methods for logging responses, stream events,
  and reconstructed stream messages
- LoggingStream wrapper that logs events as they pass through
- send_with_logger method for logged non-streaming requests
- stream_with_logger method for logged streaming requests

Co-authored-by: AI
