### PR TITLE
chore(deps): update dependency versions and upgrade reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,23 @@ binaries = []
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-base64 = "0.21.5"
-url = "2.5.0"
+base64 = "0.22"
+url = "2.5"
 time = { version = "0.3", features = ["serde", "macros", "formatting", "parsing"] }
-reqwest = { version = "0.11", features = ["json", "stream"] }
-bytes = "1.5"
+reqwest = { version = "0.13", features = ["json", "query", "stream"] }
+bytes = "1.11"
 futures = "0.3"
-tokio = { version = "1.36", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec"] }
-async-trait = "0.1.88"
-utf8path = "0.9.1"
-serde_yaml = "0.9.34"
-arrrg = "0.8.0"
-arrrg_derive = "0.8.0"
-getopts = "0.2.24"
-rustyline = "17.0.2"
-ctrlc = { version = "3.5.1", features = ["termination"] }
-biometrics = "0.12.0"
+tokio = { version = "^1.49", features = ["full"] }
+tokio-util = { version = "^0.7", features = ["codec"] }
+async-trait = "0.1"
+utf8path = "0.9"
+serde_yaml = "0.9"
+arrrg = "0.8"
+arrrg_derive = "0.8"
+getopts = "0.2"
+rustyline = "17.0"
+ctrlc = { version = "3.5", features = ["termination"] }
+biometrics = "0.12"
 
 [[bin]]
 name = "median-text"
@@ -49,8 +49,8 @@ path = "src/bin/claudius-chat.rs"
 required-features=["binaries"]
 
 [dev-dependencies]
-tokio = { version = "1.36", features = ["full", "test-util", "macros"] }
-tokio-test = "0.4"
+tokio = { version = "1.49.0", features = ["full", "test-util", "macros"] }
+tokio-test = "0.4.5"
 
 [[example]]
 name = "retry_example"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub use error::{Error, Result};
 pub use json_schema::JsonSchema;
 pub use observability::register_biometrics;
 pub use prompt::{
-    assert_contains, assert_max_length, assert_min_length, assert_not_contains, assert_test_passed,
-    test_prompt, PromptTestConfig, PromptTestResult,
+    PromptTestConfig, PromptTestResult, assert_contains, assert_max_length, assert_min_length,
+    assert_not_contains, assert_test_passed, test_prompt,
 };
 pub use render::{AgentStreamContext, PlainTextRenderer, Renderer, StreamContext};
 pub use types::*;


### PR DESCRIPTION
Relax overly-specific version pins to semver-compatible ranges across
most dependencies (e.g., base64 0.21.5 -> 0.22, tokio 1.36 -> ^1.49).
Upgrade reqwest from 0.11 to 0.13 and add the "query" feature.

Co-authored-by: AI
