### PR TITLE
refactor: replace claude-3-5-haiku with claude-haiku-4-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Test configurations can be written in YAML format with comprehensive assertion s
 ```yaml
 name: "Simple Math Test"
 prompt: "What is 2 + 2? Please respond with just the number."
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 50
 temperature: 0.0
 system: "You are a helpful math assistant."
@@ -432,7 +432,7 @@ messages:
   - role: "user"
     content: "Tell me about ownership and borrowing."
 system: "You are a helpful Rust programming tutor."
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 400
 temperature: 0.3
 expected_contains:
@@ -448,7 +448,7 @@ Configuration inheritance allows for reusable base configurations:
 ```yaml
 # base.yaml
 name: "Base Configuration"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 temperature: 0.5
 system: "You are a helpful assistant."
@@ -468,7 +468,7 @@ File references enable modular prompt and system configurations:
 name: "File Reference Test"
 prompt: "prompt.yaml"      # Contents loaded from prompt.yaml
 system: "system.md"        # Contents loaded from system.md
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 400
 expected_contains:
   - "helpful"
@@ -498,7 +498,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a test configuration
     let config = PromptTestConfig::new("What is 2 + 2?")
         .with_name("Simple Math Test")
-        .with_model("claude-3-5-haiku-latest")
+        .with_model("claude-haiku-4-5")
         .with_max_tokens(50)
         .with_temperature(0.0)
         .expect_contains("4")

--- a/base.yaml
+++ b/base.yaml
@@ -1,5 +1,5 @@
 name: "Base Configuration"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 temperature: 0.5
 system: "You are a helpful assistant."

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -53,7 +53,7 @@ use std::time::{Duration, Instant};
 /// ```rust
 /// # use claudius::PromptTestConfig;
 /// let config = PromptTestConfig::new("What is the capital of France?")
-///     .with_model("claude-3-5-haiku-latest")
+///     .with_model("claude-haiku-4-5")
 ///     .expect_contains("Paris");
 /// ```
 ///
@@ -63,7 +63,7 @@ use std::time::{Duration, Instant};
 /// name: "Geography Test"
 /// prompt: "prompt.yaml"    # Content loaded from prompt.yaml
 /// system: "system.md"      # Content loaded from system.md
-/// model: "claude-3-5-haiku-latest"
+/// model: "claude-haiku-4-5"
 /// expected_contains:
 ///   - "capital"
 /// ```
@@ -155,7 +155,7 @@ pub struct PromptTestConfig {
 }
 
 /// Default model to use for prompt tests when none is specified.
-const DEFAULT_MODEL: &str = "claude-3-5-haiku-latest";
+const DEFAULT_MODEL: &str = "claude-haiku-4-5";
 
 /// Default maximum tokens for prompt tests when none is specified.
 const DEFAULT_MAX_TOKENS: u32 = 1000;
@@ -425,7 +425,7 @@ impl PromptTestConfig {
     /// name: "My Test"
     /// prompt: "prompt.yaml"     # This file will be loaded
     /// system: "system.md"       # This file will be loaded
-    /// model: "claude-3-5-haiku-latest"
+    /// model: "claude-haiku-4-5"
     /// ```
     ///
     /// The content of `prompt.yaml` and `system.md` (relative to the config file)
@@ -1239,7 +1239,7 @@ mod tests {
 name: "Base Config"
 prompt: "Base prompt"
 system: "Base system"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 temperature: 0.5
 expected_contains:
@@ -1330,7 +1330,7 @@ prompt: "test"
         let base_yaml = r#"
 name: "Subdir Base Config"
 system: "Base system"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 "#;
         let base_file = subdir.join("base.yaml");
@@ -1389,7 +1389,7 @@ prompt: "Child prompt 2"
         let config_yaml = r#"
 name: "Relative Prompt Test"
 prompt: "prompt.yaml"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 "#;
         let config_file = test_dir.join("config.yaml");
@@ -1422,7 +1422,7 @@ max_tokens: 100
 name: "Relative System Test"
 prompt: "Hello world"
 system: "system.md"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 "#;
         let config_file = test_dir.join("config.yaml");
@@ -1462,7 +1462,7 @@ max_tokens: 100
 name: "Subdirectory Test"
 prompt: "prompt.yaml"
 system: "system.md"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 "#;
         let config_file = subdir.join("config.yaml");
         std::fs::write(&config_file, config_yaml).unwrap();
@@ -1490,7 +1490,7 @@ model: "claude-3-5-haiku-latest"
 name: "Absolute Path Test"
 prompt: "/absolute/path/prompt.yaml"
 system: "/absolute/path/system.md"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 "#;
         let config_file = test_dir.join("config.yaml");
         std::fs::write(&config_file, config_yaml).unwrap();
@@ -1527,7 +1527,7 @@ model: "claude-3-5-haiku-latest"
 name: "Parent System Test"
 prompt: "Hello world"
 system: "../system.md"
-model: "claude-3-5-haiku-latest"
+model: "claude-haiku-4-5"
 max_tokens: 100
 "#;
         let config_file = subdir.join("test.yaml");

--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -30,12 +30,6 @@ pub enum KnownModel {
     /// Claude 3.7 Sonnet (2025-02-19 version)
     Claude37Sonnet20250219,
 
-    /// Claude 3.5 Haiku (latest version)
-    Claude35HaikuLatest,
-
-    /// Claude 3.5 Haiku (2024-10-22 version)
-    Claude35Haiku20241022,
-
     /// Claude Haiku 4.5 (alias)
     ClaudeHaiku45,
 
@@ -95,8 +89,6 @@ impl fmt::Display for KnownModel {
             KnownModel::ClaudeOpus45 => write!(f, "claude-opus-4-5"),
             KnownModel::Claude37SonnetLatest => write!(f, "claude-3-7-sonnet-latest"),
             KnownModel::Claude37Sonnet20250219 => write!(f, "claude-3-7-sonnet-20250219"),
-            KnownModel::Claude35HaikuLatest => write!(f, "claude-3-5-haiku-latest"),
-            KnownModel::Claude35Haiku20241022 => write!(f, "claude-3-5-haiku-20241022"),
             KnownModel::ClaudeHaiku45 => write!(f, "claude-haiku-4-5"),
             KnownModel::ClaudeHaiku4520251001 => write!(f, "claude-haiku-4-5-20251001"),
             KnownModel::ClaudeSonnet420250514 => write!(f, "claude-sonnet-4-20250514"),
@@ -138,8 +130,6 @@ impl<'de> Deserialize<'de> for Model {
             "claude-opus-4-5" => Ok(Model::Known(KnownModel::ClaudeOpus45)),
             "claude-3-7-sonnet-latest" => Ok(Model::Known(KnownModel::Claude37SonnetLatest)),
             "claude-3-7-sonnet-20250219" => Ok(Model::Known(KnownModel::Claude37Sonnet20250219)),
-            "claude-3-5-haiku-latest" => Ok(Model::Known(KnownModel::Claude35HaikuLatest)),
-            "claude-3-5-haiku-20241022" => Ok(Model::Known(KnownModel::Claude35Haiku20241022)),
             "claude-haiku-4-5" => Ok(Model::Known(KnownModel::ClaudeHaiku45)),
             "claude-haiku-4-5-20251001" => Ok(Model::Known(KnownModel::ClaudeHaiku4520251001)),
             "claude-sonnet-4-20250514" => Ok(Model::Known(KnownModel::ClaudeSonnet420250514)),
@@ -175,8 +165,6 @@ impl FromStr for KnownModel {
             "claude-opus-4-5" => Ok(KnownModel::ClaudeOpus45),
             "claude-3-7-sonnet-latest" => Ok(KnownModel::Claude37SonnetLatest),
             "claude-3-7-sonnet-20250219" => Ok(KnownModel::Claude37Sonnet20250219),
-            "claude-3-5-haiku-latest" => Ok(KnownModel::Claude35HaikuLatest),
-            "claude-3-5-haiku-20241022" => Ok(KnownModel::Claude35Haiku20241022),
             "claude-haiku-4-5" => Ok(KnownModel::ClaudeHaiku45),
             "claude-haiku-4-5-20251001" => Ok(KnownModel::ClaudeHaiku4520251001),
             "claude-sonnet-4-20250514" => Ok(KnownModel::ClaudeSonnet420250514),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28,7 +28,7 @@ mod tests {
                 "Say 'test passed'".to_string(),
                 MessageRole::User,
             )],
-            Model::Known(KnownModel::Claude35HaikuLatest),
+            Model::Known(KnownModel::ClaudeHaiku45),
         );
 
         let response = client.send(params).await;
@@ -54,7 +54,7 @@ mod tests {
                 "Count to 3".to_string(),
                 MessageRole::User,
             )],
-            Model::Known(KnownModel::Claude35HaikuLatest),
+            Model::Known(KnownModel::ClaudeHaiku45),
         );
 
         let stream = client.stream(&params).await;
@@ -199,27 +199,25 @@ mod tests {
                 "Say 'streaming test passed' briefly".to_string(),
                 MessageRole::User,
             )],
-            Model::Known(KnownModel::Claude35HaikuLatest),
+            Model::Known(KnownModel::ClaudeHaiku45),
         );
 
         let result = client.stream(&params).await;
-        assert!(
-            result.is_ok(),
-            "Streaming request should succeed with env API key"
-        );
+        let stream = match result {
+            Ok(stream) => stream,
+            Err(err) => panic!("Streaming request failed with env API key: {err:?}"),
+        };
 
         // Verify we get a proper stream by consuming at least one event
-        if let Ok(stream) = result {
-            use futures::StreamExt;
-            let mut pinned_stream = std::pin::pin!(stream);
-            let first_event = pinned_stream.next().await;
-            assert!(
-                first_event.is_some(),
-                "Stream should yield at least one event"
-            );
-            if let Some(event_result) = first_event {
-                assert!(event_result.is_ok(), "First stream event should be valid");
-            }
+        use futures::StreamExt;
+        let mut pinned_stream = std::pin::pin!(stream);
+        let first_event = pinned_stream.next().await;
+        assert!(
+            first_event.is_some(),
+            "Stream should yield at least one event"
+        );
+        if let Some(event_result) = first_event {
+            assert!(event_result.is_ok(), "First stream event should be valid");
         }
     }
 
@@ -239,28 +237,26 @@ mod tests {
                 "Say 'non-streaming test passed' briefly".to_string(),
                 MessageRole::User,
             )],
-            Model::Known(KnownModel::Claude35HaikuLatest),
+            Model::Known(KnownModel::ClaudeHaiku45),
         );
 
         let response = client.send(params).await;
-        assert!(
-            response.is_ok(),
-            "Non-streaming request should succeed with env API key"
-        );
+        let message = match response {
+            Ok(message) => message,
+            Err(err) => panic!("Non-streaming request failed with env API key: {err:?}"),
+        };
 
-        if let Ok(message) = response {
-            assert!(
-                !message.content.is_empty(),
-                "Response should contain content"
-            );
-            assert!(
-                message.usage.input_tokens > 0,
-                "Should report input token usage"
-            );
-            assert!(
-                message.usage.output_tokens > 0,
-                "Should report output token usage"
-            );
-        }
+        assert!(
+            !message.content.is_empty(),
+            "Response should contain content"
+        );
+        assert!(
+            message.usage.input_tokens > 0,
+            "Should report input token usage"
+        );
+        assert!(
+            message.usage.output_tokens > 0,
+            "Should report output token usage"
+        );
     }
 }


### PR DESCRIPTION
Remove deprecated claude-3-5-haiku-latest and claude-3-5-haiku-20241022
model variants from KnownModel enum and update all references to use the
claude-haiku-4-5 model identifier instead.

- Remove Claude35HaikuLatest and Claude35Haiku20241022 enum variants
  and their Display, Deserialize, and FromStr implementations
- Update DEFAULT_MODEL, base.yaml, docs, and test configs
- Replace assert!(result.is_ok()) with match/panic in integration tests
  for clearer error reporting on failure

Co-authored-by: AI
