### PR TITLE
fix(agent): split input/output cost in budget

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -965,6 +965,37 @@ impl Budget {
             .unwrap_or(u64::MAX)
     }
 
+    /// Calculates the cost in micro-cents for only input tokens in a usage record.
+    ///
+    /// This includes input tokens, cache creation tokens, and cache read tokens.
+    /// Output tokens are excluded.
+    ///
+    /// # Returns
+    ///
+    /// Input cost in micro-cents as a `u64`
+    pub fn calculate_input_cost(&self, usage: &crate::Usage) -> u64 {
+        let input_cost =
+            (usage.input_tokens.max(0) as u64).saturating_mul(self.input_token_rate_micro_cents);
+        let cache_creation_cost = (usage.cache_creation_input_tokens.unwrap_or(0).max(0) as u64)
+            .saturating_mul(self.cache_creation_token_rate_micro_cents);
+        let cache_read_cost = (usage.cache_read_input_tokens.unwrap_or(0).max(0) as u64)
+            .saturating_mul(self.cache_read_token_rate_micro_cents);
+
+        input_cost
+            .checked_add(cache_creation_cost)
+            .and_then(|sum| sum.checked_add(cache_read_cost))
+            .unwrap_or(u64::MAX)
+    }
+
+    /// Calculates the cost in micro-cents for only output tokens in a usage record.
+    ///
+    /// # Returns
+    ///
+    /// Output cost in micro-cents as a `u64`
+    pub fn calculate_output_cost(&self, usage: &crate::Usage) -> u64 {
+        (usage.output_tokens.max(0) as u64).saturating_mul(self.output_token_rate_micro_cents)
+    }
+
     /// Attempts to allocate cost for the expected maximum tokens from the budget.
     ///
     /// Returns `Some(BudgetAllocation)` if sufficient budget is available,
@@ -983,7 +1014,7 @@ impl Budget {
     /// }
     /// ```
     pub fn allocate(&self, max_tokens: u32) -> Option<BudgetAllocation<'_>> {
-        let max_cost = self.calculate_max_cost_for_tokens(max_tokens);
+        let max_cost = self.calculate_output_cost_for_tokens(max_tokens);
         loop {
             let witness = self.remaining_micro_cents.load(Ordering::Relaxed);
             if witness >= max_cost
@@ -1009,27 +1040,14 @@ impl Budget {
         }
     }
 
-    /// Calculates the maximum possible cost for the given number of tokens.
+    /// Calculates the output token cost for the given number of tokens.
     ///
-    /// This method uses the highest token rate among all configured rates to
-    /// provide a conservative (worst-case) cost estimate for allocation purposes.
-    ///
-    /// # Safety
-    ///
-    /// This method performs multiplication of `u32` and `u64` values. While overflow
-    /// is theoretically possible with extreme values, it would require:
-    /// - More than 4 billion tokens (u32::MAX)
-    /// - AND token rates exceeding u64::MAX / u32::MAX (≈4.3 billion micro-cents per token)
-    ///
-    /// Such values would represent costs far beyond reasonable API usage scenarios.
-    /// In practice, this method is safe for all realistic budget and token rate combinations.
-    fn calculate_max_cost_for_tokens(&self, tokens: u32) -> u64 {
-        (tokens as u64).saturating_mul(
-            self.output_token_rate_micro_cents
-                .max(self.input_token_rate_micro_cents)
-                .max(self.cache_creation_token_rate_micro_cents)
-                .max(self.cache_read_token_rate_micro_cents),
-        )
+    /// This is used to size budget allocations, which track output token budgets.
+    /// Input token costs are charged directly to the main budget rather than
+    /// the per-turn allocation, because input costs grow with conversation
+    /// history and are not under the agent's control.
+    fn calculate_output_cost_for_tokens(&self, tokens: u32) -> u64 {
+        (tokens as u64).saturating_mul(self.output_token_rate_micro_cents)
     }
 
     /// Returns the current remaining budget in micro-cents.
@@ -1116,7 +1134,7 @@ impl Budget {
         }
     }
 
-    fn consume_cost_micro_cents_saturating(&self, cost_micro_cents: u64) -> u64 {
+    pub(crate) fn consume_cost_micro_cents_saturating(&self, cost_micro_cents: u64) -> u64 {
         loop {
             let witness = self.remaining_micro_cents.load(Ordering::Relaxed);
             if witness == 0 {
@@ -1263,60 +1281,50 @@ impl<'a> BudgetAllocation<'a> {
         }
     }
 
-    /// Returns an approximation of remaining tokens based on the highest token rate.
+    /// Consumes budget for a complete API response, splitting costs appropriately.
     ///
-    /// This method provides a conservative estimate of how many more tokens could
-    /// be consumed from this allocation. It uses the highest token rate configured
-    /// in the original budget to ensure the estimate doesn't exceed what's actually
-    /// affordable.
+    /// Output token costs are charged to this allocation, which represents the
+    /// agent's generation budget for the current turn. Input token costs (input,
+    /// cache creation, cache read) are charged directly to the main budget because
+    /// they grow with conversation history and are not under the agent's control.
+    ///
+    /// This prevents input token costs from starving the output budget as
+    /// conversations grow longer over multiple tool-use steps.
     ///
     /// # Returns
     ///
-    /// Approximate number of tokens that can still be consumed, calculated as:
-    /// `remaining_micro_cents() / highest_token_rate`
+    /// - `true` if the output cost was within the remaining allocation
+    /// - `false` if the output cost exceeds the remaining allocation
     ///
-    /// # Example
+    /// Input costs are always deducted from the main budget (saturating at zero)
+    /// regardless of the return value, because the API call already happened.
+    #[must_use]
+    pub fn consume_response(&mut self, usage: &crate::Usage) -> bool {
+        let input_cost = self.budget.calculate_input_cost(usage);
+        let output_cost = self.budget.calculate_output_cost(usage);
+
+        // Charge input costs to main budget (sunk cost from the API call).
+        self.budget.consume_cost_micro_cents_saturating(input_cost);
+
+        // Charge output costs to allocation.
+        if output_cost <= self.allocated_micro_cents {
+            self.allocated_micro_cents -= output_cost;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the number of output tokens that can still be generated from this allocation.
     ///
-    /// ```rust
-    /// use claudius::{Budget, Usage};
-    ///
-    /// let budget = Budget::new_with_rates(
-    ///     100_000, // 100k micro-cents
-    ///     300,     // Input: 300 micro-cents/token
-    ///     1500,    // Output: 1500 micro-cents/token (highest)
-    ///     150,     // Cache creation: 150 micro-cents/token
-    ///     75,      // Cache read: 75 micro-cents/token
-    /// );
-    ///
-    /// let mut allocation = budget.allocate(50).unwrap();
-    /// // Initially: 50 tokens * 1500 = 75,000 micro-cents allocated
-    /// assert_eq!(allocation.remaining_tokens(), 50); // 75,000 / 1500
-    ///
-    /// // Consume some budget with cheaper input tokens
-    /// let usage = Usage::new(20, 5); // Cost: (20*300) + (5*1500) = 13,500
-    /// allocation.consume_usage(&usage);
-    ///
-    /// // Remaining: 75,000 - 13,500 = 61,500 micro-cents
-    /// assert_eq!(allocation.remaining_tokens(), 41); // 61,500 / 1500
-    /// ```
-    ///
-    /// # Conservative Estimation
-    ///
-    /// This method intentionally provides a conservative (lower) estimate by
-    /// using the highest token rate. The actual number of tokens you can
-    /// consume may be higher if you use cheaper token types.
+    /// This method uses the output token rate because allocations track output
+    /// token budgets. Input token costs are charged directly to the main budget
+    /// and do not reduce this allocation.
     pub fn remaining_tokens(&self) -> u32 {
-        let highest_rate = self
-            .budget
-            .output_token_rate_micro_cents
-            .max(self.budget.input_token_rate_micro_cents)
-            .max(self.budget.cache_creation_token_rate_micro_cents)
-            .max(self.budget.cache_read_token_rate_micro_cents);
-        if highest_rate > 0 {
+        let rate = self.budget.output_token_rate_micro_cents;
+        if rate > 0 {
             std::cmp::min(
-                self.allocated_micro_cents
-                    .checked_div(highest_rate)
-                    .unwrap_or(0),
+                self.allocated_micro_cents.checked_div(rate).unwrap_or(0),
                 u32::MAX as u64,
             ) as u32
         } else {
@@ -2680,8 +2688,9 @@ async fn step_default_turn_impl<A: Agent>(
     let mut usage_total = Usage::new(0, 0);
     let mut request_count: u64 = 0;
     loop {
+        let max_tokens = std::cmp::min(agent.max_tokens().await, tokens_rem.remaining_tokens());
         let req = agent
-            .create_request(tokens_rem.remaining_tokens(), messages.clone(), stream)
+            .create_request(max_tokens, messages.clone(), stream)
             .await;
         if let Err(err) = agent.hook_message_create_params(&req).await {
             return ControlFlow::Break(Err(err));
@@ -2717,7 +2726,7 @@ async fn step_default_turn_impl<A: Agent>(
             content: MessageParamContent::Array(resp.content.clone()),
         };
         usage_total = usage_total + resp.usage;
-        if !tokens_rem.consume_usage(&resp.usage) {
+        if !tokens_rem.consume_response(&resp.usage) {
             return ControlFlow::Break(Ok(TurnOutcome {
                 stop_reason: StopReason::MaxTokens,
                 usage: usage_total,
@@ -4262,14 +4271,22 @@ mod tests {
 
     #[test]
     fn budget_allocate_maximum_tokens_calculation() {
-        // Test that allocation uses the highest token rate for max cost calculation
-        let budget = Budget::new_with_rates(10000, 5, 15, 25, 10); // max rate is 25
+        // Allocation uses the output token rate because allocations track output budgets.
+        let budget = Budget::new_with_rates(10000, 5, 15, 25, 10); // output rate is 15
 
         let allocation = budget.allocate(200);
         assert!(allocation.is_some());
 
-        // Should reserve 200 * 25 = 5000 micro-cents
-        assert_eq!(budget.remaining_micro_cents(), 5000);
+        // Should reserve 200 * 15 = 3000 micro-cents (output rate)
+        assert_eq!(budget.remaining_micro_cents(), 7000);
+
+        drop(allocation);
+
+        // A flat-rate budget should allocate at the flat rate.
+        let budget2 = Budget::new_flat_rate(10000, 25);
+        let allocation2 = budget2.allocate(200);
+        assert!(allocation2.is_some());
+        assert_eq!(budget2.remaining_micro_cents(), 5000);
     }
 
     // Budget Consumption Tests
@@ -4351,6 +4368,138 @@ mod tests {
 
         // Allocation should remain unchanged
         assert_eq!(allocation.remaining_micro_cents(), 500);
+    }
+
+    #[test]
+    fn calculate_input_cost_sums_non_output_tokens() {
+        let budget = Budget::new_with_rates(1_000_000, 300, 1500, 375, 30);
+        let usage = Usage::new(100, 50)
+            .with_cache_creation_input_tokens(20)
+            .with_cache_read_input_tokens(10);
+
+        let input_cost = budget.calculate_input_cost(&usage);
+        // 100*300 + 20*375 + 10*30 = 30000 + 7500 + 300 = 37800
+        assert_eq!(input_cost, 37800);
+    }
+
+    #[test]
+    fn calculate_output_cost_only_counts_output_tokens() {
+        let budget = Budget::new_with_rates(1_000_000, 300, 1500, 375, 30);
+        let usage = Usage::new(100, 50)
+            .with_cache_creation_input_tokens(20)
+            .with_cache_read_input_tokens(10);
+
+        let output_cost = budget.calculate_output_cost(&usage);
+        // 50*1500 = 75000
+        assert_eq!(output_cost, 75000);
+    }
+
+    #[test]
+    fn input_plus_output_cost_equals_total_cost() {
+        let budget = Budget::new_with_rates(1_000_000, 300, 1500, 375, 30);
+        let usage = Usage::new(100, 50)
+            .with_cache_creation_input_tokens(20)
+            .with_cache_read_input_tokens(10);
+
+        let total = budget.calculate_cost(&usage);
+        let split = budget.calculate_input_cost(&usage) + budget.calculate_output_cost(&usage);
+        assert_eq!(total, split);
+    }
+
+    #[test]
+    fn consume_response_charges_output_to_allocation_input_to_budget() {
+        // Rates: input=300, output=1500, cache_creation=375, cache_read=30
+        let budget = Budget::new_with_rates(500_000_000, 300, 1500, 375, 30);
+        let initial_budget = budget.remaining_micro_cents();
+
+        // Allocate for 100 output tokens: 100 * 1500 = 150_000
+        let mut allocation = budget.allocate(100).unwrap();
+        assert_eq!(budget.remaining_micro_cents(), initial_budget - 150_000);
+        assert_eq!(allocation.remaining_tokens(), 100);
+
+        // Simulate an API response with 2000 input + 30 output tokens
+        let usage = Usage::new(2000, 30).with_cache_read_input_tokens(500);
+
+        let input_cost = budget.calculate_input_cost(&usage);
+        // 2000*300 + 500*30 = 600_000 + 15_000 = 615_000
+
+        assert!(allocation.consume_response(&usage));
+
+        // Allocation should only lose output cost: 30 * 1500 = 45_000
+        // Remaining in allocation: 150_000 - 45_000 = 105_000 = 70 tokens
+        assert_eq!(allocation.remaining_tokens(), 70);
+
+        // Main budget should have been charged the input cost
+        assert_eq!(
+            budget.remaining_micro_cents(),
+            initial_budget - 150_000 - input_cost
+        );
+    }
+
+    #[test]
+    fn consume_response_input_does_not_starve_output_budget() {
+        // This test demonstrates the fix: large input costs don't drain the output budget.
+        let budget = Budget::new_with_rates(500_000_000, 300, 1500, 375, 30);
+
+        let mut allocation = budget.allocate(4096).unwrap();
+        // Output allocation: 4096 * 1500 = 6_144_000
+
+        // Step 1: 2000 input, 500 output
+        let usage1 = Usage::new(2000, 500);
+        assert!(allocation.consume_response(&usage1));
+        // Allocation loses 500 * 1500 = 750_000. Remaining output: 3596 tokens.
+        assert_eq!(allocation.remaining_tokens(), 3596);
+
+        // Step 2: 5000 input (conversation grew), 400 output
+        let usage2 = Usage::new(5000, 400);
+        assert!(allocation.consume_response(&usage2));
+        // Allocation loses 400 * 1500 = 600_000. Remaining output: 3196 tokens.
+        assert_eq!(allocation.remaining_tokens(), 3196);
+
+        // Step 3: 10000 input (big tool results), 300 output
+        let usage3 = Usage::new(10000, 300);
+        assert!(allocation.consume_response(&usage3));
+        // Allocation loses 300 * 1500 = 450_000. Remaining output: 2896 tokens.
+        assert_eq!(allocation.remaining_tokens(), 2896);
+
+        // With consume_usage (old behavior), the allocation would have been exhausted
+        // by step 2 or 3 due to input costs draining it.
+        // With consume_response, the agent still has 2896 output tokens available.
+    }
+
+    #[test]
+    fn consume_response_returns_false_when_output_exceeds_allocation() {
+        let budget = Budget::new_with_rates(500_000_000, 300, 1500, 375, 30);
+        let mut allocation = budget.allocate(50).unwrap();
+        // Output allocation: 50 * 1500 = 75_000
+
+        // Response with 100 output tokens (cost 150_000 > allocation 75_000)
+        let usage = Usage::new(10, 100);
+        assert!(!allocation.consume_response(&usage));
+    }
+
+    #[test]
+    fn remaining_tokens_uses_output_rate() {
+        // When output rate differs from highest rate, remaining_tokens should
+        // use the output rate since allocation tracks output budgets.
+        let budget = Budget::new_with_rates(100_000, 300, 1500, 3750, 30);
+        // cache_creation (3750) is the highest rate, output is 1500
+
+        let allocation = budget.allocate(50).unwrap();
+        // Allocated: 50 * 1500 = 75_000 (output rate)
+        // remaining_tokens = 75_000 / 1500 = 50
+        assert_eq!(allocation.remaining_tokens(), 50);
+    }
+
+    #[test]
+    fn allocate_uses_output_rate_not_highest_rate() {
+        let budget = Budget::new_with_rates(100_000, 300, 1500, 3750, 30);
+        // Highest rate is 3750 (cache_creation), output rate is 1500
+
+        let allocation = budget.allocate(50).unwrap();
+        // Allocated at output rate: 50 * 1500 = 75_000
+        assert_eq!(budget.remaining_micro_cents(), 25_000);
+        assert_eq!(allocation.remaining_tokens(), 50);
     }
 
     // Budget State Management Tests


### PR DESCRIPTION
Budget allocations previously charged all token costs against a single
pool sized by the maximum token rate. As conversations grew, rising
input costs consumed the per-turn allocation, starving the agent's
output budget and causing premature MaxTokens stops.

Split cost tracking so output costs are charged to the per-turn
allocation while input costs go directly to the main budget:
- Add calculate_input_cost() and calculate_output_cost() to Budget
- Add consume_response() on BudgetAllocation that routes input costs
  to the main budget and output costs to the allocation
- Size allocations using output rate instead of max-of-all-rates
- Cap max_tokens by agent.max_tokens() in the turn loop

Co-authored-by: AI
