### PR TITLE
v0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2024"
 description = "SDK for the Anthropic API"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claudius
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)
-![Version](https://img.shields.io/badge/version-0.16.0-green.svg)
+![Version](https://img.shields.io/badge/version-0.20.0-green.svg)
 
 Claudius is a comprehensive Rust SDK for the Anthropic API, providing both low-level API access and a 
 powerful agent framework for building AI-powered applications. This library enables seamless integration 
@@ -73,7 +73,7 @@ Add Claudius to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-claudius = "0.16.0"
+claudius = "0.20.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
Bump version to 0.20.0 in Cargo.toml and update stale version
references (0.16.0) in README.md badge and dependency example.

Co-authored-by: AI
