### PR TITLE
refactor(cache): centralize cache control placement

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,21 +8,18 @@ use std::time::Instant;
 use futures::StreamExt;
 use utf8path::Path;
 
-use crate::cache_control::{
-    MAX_CACHE_BREAKPOINTS, count_system_cache_controls, prune_cache_controls_in_messages,
-};
+use crate::cache_control::apply_cache_controls;
 use crate::observability::{
     AGENT_TOOL_CALLS, AGENT_TOOL_DURATION, AGENT_TOOL_ERRORS, AGENT_TURN_DURATION,
     AGENT_TURN_REQUESTS,
 };
 use crate::{
-    AccumulatingStream, AgentStreamContext, Anthropic, CacheControlEphemeral, ContentBlock,
-    ContentBlockDelta, Error, KnownModel, Message, MessageCreateParams, MessageParam,
-    MessageParamContent, MessageRole, MessageStreamEvent, Metadata, Model, Renderer, StopReason,
-    StreamContext, SystemPrompt, ThinkingConfig, ToolBash20241022, ToolBash20250124, ToolChoice,
-    ToolParam, ToolResultBlock, ToolResultBlockContent, ToolTextEditor20250124,
-    ToolTextEditor20250429, ToolTextEditor20250728, ToolUnionParam, ToolUseBlock, Usage,
-    WebSearchTool20250305, push_or_merge_message,
+    AccumulatingStream, AgentStreamContext, Anthropic, ContentBlock, ContentBlockDelta, Error,
+    KnownModel, Message, MessageCreateParams, MessageParam, MessageParamContent, MessageRole,
+    MessageStreamEvent, Metadata, Model, Renderer, StopReason, StreamContext, SystemPrompt,
+    ThinkingConfig, ToolBash20241022, ToolBash20250124, ToolChoice, ToolParam, ToolResultBlock,
+    ToolResultBlockContent, ToolTextEditor20250124, ToolTextEditor20250429, ToolTextEditor20250728,
+    ToolUnionParam, ToolUseBlock, Usage, WebSearchTool20250305, push_or_merge_message,
 };
 
 struct StreamingContext<'a> {
@@ -1587,6 +1584,11 @@ pub trait Agent: Send + Sync + Sized {
         None
     }
 
+    /// Returns whether prompt caching is enabled.
+    fn caching_enabled(&self) -> bool {
+        false
+    }
+
     /// Returns the temperature for response generation.
     async fn temperature(&self) -> Option<f32> {
         None
@@ -1978,11 +1980,11 @@ pub trait Agent: Send + Sync + Sized {
         messages: Vec<MessageParam>,
         stream: bool,
     ) -> MessageCreateParams {
-        let system = self.system().await;
+        let mut system = self.system().await;
         let mut messages = messages;
-        let system_cache_controls = count_system_cache_controls(&system);
-        let keep_latest = MAX_CACHE_BREAKPOINTS.saturating_sub(system_cache_controls);
-        prune_cache_controls_in_messages(&mut messages, keep_latest);
+        if self.caching_enabled() {
+            apply_cache_controls(&mut system, &mut messages);
+        }
 
         let tools = self
             .tools()
@@ -2623,56 +2625,16 @@ fn push_tool_result(
 ) {
     match result {
         Ok(block) => {
-            let mut block = block;
-            if block.cache_control.is_none() {
-                block.cache_control = Some(CacheControlEphemeral::new());
-            }
             if let Some((renderer, context)) = renderer {
                 render_tool_result_block(renderer, context, &block);
             }
             tool_results.push(block.into());
         }
         Err(block) => {
-            let mut block = block;
-            if block.cache_control.is_none() {
-                block.cache_control = Some(CacheControlEphemeral::new());
-            }
             if let Some((renderer, context)) = renderer {
                 render_tool_result_block(renderer, context, &block);
             }
             tool_results.push(block.with_error(true).into());
-        }
-    }
-    prune_tool_result_cache_controls(tool_results, 4);
-}
-
-fn prune_tool_result_cache_controls(tool_results: &mut [ContentBlock], keep_latest: usize) {
-    if keep_latest == 0 {
-        for block in tool_results.iter_mut() {
-            if let ContentBlock::ToolResult(tool_result) = block {
-                tool_result.cache_control = None;
-            }
-        }
-        return;
-    }
-
-    let mut cached_indices = Vec::new();
-    for (idx, block) in tool_results.iter().enumerate() {
-        if let ContentBlock::ToolResult(tool_result) = block
-            && tool_result.cache_control.is_some()
-        {
-            cached_indices.push(idx);
-        }
-    }
-
-    if cached_indices.len() <= keep_latest {
-        return;
-    }
-
-    let drop_count = cached_indices.len() - keep_latest;
-    for idx in cached_indices.into_iter().take(drop_count) {
-        if let ContentBlock::ToolResult(tool_result) = &mut tool_results[idx] {
-            tool_result.cache_control = None;
         }
     }
 }

--- a/src/cache_control.rs
+++ b/src/cache_control.rs
@@ -1,85 +1,120 @@
-//! Shared cache_control utilities for request construction.
+//! Cache control for Anthropic prompt caching.
+//!
+//! The prefix up to and including each cache_control breakpoint must hash identically across
+//! requests.  Breakpoints that land on varying content (timestamps, the latest user message, new
+//! tool results) produce a different prefix hash on every call, miss the cache, and pay for a fresh
+//! write each time.
+//!
+//! This module provides a single entry point — [`apply_cache_controls`] — that clears any existing
+//! markers, sets one breakpoint on the system prompt, and then places additional breakpoints every
+//! [`CACHE_BREAKPOINT_INTERVAL`] content blocks throughout the messages.  When the total exceeds
+//! [`MAX_MESSAGE_BREAKPOINTS`], the earliest message breakpoints are dropped to make room.  Because
+//! the placement is deterministic and based only on block position, every request with the same
+//! prefix produces identical breakpoint placement and therefore identical prefix hashes.
 
 use crate::types::{
-    CacheControlEphemeral, ContentBlock, MessageParam, MessageParamContent, MessageRole,
-    SystemPrompt, TextBlock,
+    CacheControlEphemeral, ContentBlock, MessageParam, MessageParamContent, SystemPrompt, TextBlock,
 };
 
 /// Maximum number of cache control breakpoints allowed by the API.
-pub const MAX_CACHE_BREAKPOINTS: usize = 4;
+const MAX_CACHE_BREAKPOINTS: usize = 4;
 
-/// Count cache_control markers present in the system prompt.
-pub fn count_system_cache_controls(system: &Option<SystemPrompt>) -> usize {
-    match system {
-        Some(SystemPrompt::Blocks(blocks)) => blocks
-            .iter()
-            .filter(|block| block.block.cache_control.is_some())
-            .count(),
-        _ => 0,
-    }
-}
+/// One breakpoint is always reserved for the system prompt.
+const MAX_MESSAGE_BREAKPOINTS: usize = MAX_CACHE_BREAKPOINTS - 1;
 
-/// Remove cache_control markers so the latest N remain in the request.
-pub fn prune_cache_controls_in_messages(messages: &mut [MessageParam], keep_latest: usize) {
-    if keep_latest == 0 {
-        for message in messages.iter_mut() {
-            clear_cache_control_from_message(message);
-        }
-        return;
-    }
+/// Interval in content blocks between cache breakpoints within messages.
+const CACHE_BREAKPOINT_INTERVAL: usize = 20;
 
-    let mut cached_positions = Vec::new();
-    for (msg_idx, message) in messages.iter().enumerate() {
-        if let MessageParamContent::Array(blocks) = &message.content {
-            for (block_idx, block) in blocks.iter().enumerate() {
-                if block_has_cache_control(block) {
-                    cached_positions.push((msg_idx, block_idx));
-                }
-            }
-        }
-    }
-
-    if cached_positions.len() <= keep_latest {
-        return;
-    }
-
-    let drop_count = cached_positions.len() - keep_latest;
-    for (msg_idx, block_idx) in cached_positions.into_iter().take(drop_count) {
-        if let MessageParamContent::Array(blocks) = &mut messages[msg_idx].content
-            && let Some(block) = blocks.get_mut(block_idx)
-        {
-            clear_cache_control_on_block(block);
-        }
-    }
-}
-
-/// Applies cache_control markers to the last content block of up to N user messages.
+/// Apply cache_control markers to a system prompt and messages for a single API request.
 ///
-/// The system prompt uses one cache breakpoint, so we apply markers to the last
-/// (MAX_CACHE_BREAKPOINTS - 1) user messages. This function first clears any existing
-/// cache_control markers to avoid exceeding the API limit of 4 breakpoints.
-pub fn apply_cache_control_to_messages(messages: &mut [MessageParam]) {
-    // First, clear all existing cache_control markers from all messages.
+/// All existing cache_control markers are cleared first so that placement is entirely determined by
+/// this function.  One breakpoint is always reserved for the system prompt.  The remaining budget
+/// ([`MAX_MESSAGE_BREAKPOINTS`]) is filled by placing a breakpoint every
+/// [`CACHE_BREAKPOINT_INTERVAL`] content blocks throughout `messages`.  When there are more
+/// candidates than the budget allows, the earliest message breakpoints are removed first, keeping
+/// the later (longer-prefix) breakpoints that maximize cache value.
+pub fn apply_cache_controls(system: &mut Option<SystemPrompt>, messages: &mut [MessageParam]) {
+    // Clear every existing marker so placement is fully deterministic.
+    clear_system_cache_controls(system);
     for msg in messages.iter_mut() {
         clear_cache_control_from_message(msg);
     }
 
-    // Find indices of user messages (in reverse order).
-    let user_indices: Vec<usize> = messages
-        .iter()
-        .enumerate()
-        .filter(|(_, msg)| msg.role == MessageRole::User)
-        .map(|(idx, _)| idx)
-        .rev()
-        .take(MAX_CACHE_BREAKPOINTS - 1) // Reserve one breakpoint for system prompt.
-        .collect();
+    // The system prompt always gets a breakpoint.
+    apply_cache_control_to_system(system);
 
-    for idx in user_indices {
-        apply_cache_control_to_message(&mut messages[idx]);
+    // Walk every content block and note the position of every CACHE_BREAKPOINT_INTERVAL-th block.
+    let mut block_counter: usize = 0;
+    let mut candidates: Vec<(usize, usize)> = Vec::new();
+    for (msg_idx, message) in messages.iter().enumerate() {
+        let num_blocks = match &message.content {
+            MessageParamContent::Array(blocks) => blocks.len(),
+            MessageParamContent::String(_) => 1,
+        };
+        for block_idx in 0..num_blocks {
+            block_counter += 1;
+            if block_counter.is_multiple_of(CACHE_BREAKPOINT_INTERVAL) {
+                candidates.push((msg_idx, block_idx));
+            }
+        }
+    }
+
+    // Drop the earliest candidates to stay within budget.
+    while candidates.len() > MAX_MESSAGE_BREAKPOINTS {
+        candidates.remove(0);
+    }
+
+    for (msg_idx, block_idx) in candidates {
+        apply_cache_control_at(messages, msg_idx, block_idx);
     }
 }
 
-/// Clears cache_control from all content blocks in a message.
+/// Set cache_control on the last block of the system prompt, converting from String to Blocks when
+/// necessary.
+fn apply_cache_control_to_system(system: &mut Option<SystemPrompt>) {
+    match system {
+        Some(SystemPrompt::String(text)) => {
+            let block =
+                TextBlock::new(text.clone()).with_cache_control(CacheControlEphemeral::new());
+            *system = Some(SystemPrompt::from_blocks(vec![block]));
+        }
+        Some(SystemPrompt::Blocks(blocks)) => {
+            if let Some(last) = blocks.last_mut() {
+                last.block.cache_control = Some(CacheControlEphemeral::new());
+            }
+        }
+        None => {}
+    }
+}
+
+/// Clear all cache_control markers from the system prompt.
+fn clear_system_cache_controls(system: &mut Option<SystemPrompt>) {
+    if let Some(SystemPrompt::Blocks(blocks)) = system {
+        for block in blocks.iter_mut() {
+            block.block.cache_control = None;
+        }
+    }
+}
+
+/// Set cache_control on a specific block within a message.
+fn apply_cache_control_at(messages: &mut [MessageParam], msg_idx: usize, block_idx: usize) {
+    let message = &mut messages[msg_idx];
+    match &mut message.content {
+        MessageParamContent::String(text) => {
+            let block = ContentBlock::Text(
+                TextBlock::new(text.clone()).with_cache_control(CacheControlEphemeral::new()),
+            );
+            message.content = MessageParamContent::Array(vec![block]);
+        }
+        MessageParamContent::Array(blocks) => {
+            if let Some(block) = blocks.get_mut(block_idx) {
+                set_cache_control_on_block(block);
+            }
+        }
+    }
+}
+
+/// Clear cache_control from all content blocks in a message.
 fn clear_cache_control_from_message(message: &mut MessageParam) {
     if let MessageParamContent::Array(blocks) = &mut message.content {
         for block in blocks.iter_mut() {
@@ -88,7 +123,7 @@ fn clear_cache_control_from_message(message: &mut MessageParam) {
     }
 }
 
-/// Clears cache_control on a content block.
+/// Clear cache_control on a single content block.
 fn clear_cache_control_on_block(block: &mut ContentBlock) {
     match block {
         ContentBlock::Text(text_block) => {
@@ -112,31 +147,11 @@ fn clear_cache_control_on_block(block: &mut ContentBlock) {
         ContentBlock::WebSearchToolResult(web_search_result) => {
             web_search_result.cache_control = None;
         }
-        // Thinking blocks don't support cache_control.
         ContentBlock::Thinking(_) | ContentBlock::RedactedThinking(_) => {}
     }
 }
 
-/// Applies cache_control to the last content block of a single message.
-pub(crate) fn apply_cache_control_to_message(message: &mut MessageParam) {
-    match &mut message.content {
-        MessageParamContent::String(text) => {
-            // Convert string to a single text block with cache_control.
-            let block = ContentBlock::Text(
-                TextBlock::new(text.clone()).with_cache_control(CacheControlEphemeral::new()),
-            );
-            message.content = MessageParamContent::Array(vec![block]);
-        }
-        MessageParamContent::Array(blocks) => {
-            // Find the last cacheable block and add cache_control.
-            if let Some(last_block) = blocks.last_mut() {
-                set_cache_control_on_block(last_block);
-            }
-        }
-    }
-}
-
-/// Sets cache_control on a content block if it supports caching.
+/// Set cache_control on a content block that supports caching.
 fn set_cache_control_on_block(block: &mut ContentBlock) {
     match block {
         ContentBlock::Text(text_block) => {
@@ -148,7 +163,6 @@ fn set_cache_control_on_block(block: &mut ContentBlock) {
         ContentBlock::ToolUse(tool_use) => {
             tool_use.cache_control = Some(CacheControlEphemeral::new());
         }
-        // Other block types don't support cache_control in user messages.
         ContentBlock::Image(_)
         | ContentBlock::Document(_)
         | ContentBlock::ServerToolUse(_)
@@ -158,17 +172,332 @@ fn set_cache_control_on_block(block: &mut ContentBlock) {
     }
 }
 
-fn block_has_cache_control(block: &ContentBlock) -> bool {
-    match block {
-        ContentBlock::Text(text_block) => text_block.cache_control.is_some(),
-        ContentBlock::ToolResult(tool_result) => tool_result.cache_control.is_some(),
-        ContentBlock::ToolUse(tool_use) => tool_use.cache_control.is_some(),
-        ContentBlock::Image(image_block) => image_block.cache_control.is_some(),
-        ContentBlock::Document(document_block) => document_block.cache_control.is_some(),
-        ContentBlock::ServerToolUse(server_tool_use) => server_tool_use.cache_control.is_some(),
-        ContentBlock::WebSearchToolResult(web_search_result) => {
-            web_search_result.cache_control.is_some()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MessageRole;
+
+    fn text_block(text: &str) -> ContentBlock {
+        ContentBlock::Text(TextBlock::new(text))
+    }
+
+    fn user_msg_with_blocks(n: usize, prefix: &str) -> MessageParam {
+        let blocks: Vec<ContentBlock> = (0..n)
+            .map(|i| text_block(&format!("{prefix}{i}")))
+            .collect();
+        MessageParam {
+            role: MessageRole::User,
+            content: MessageParamContent::Array(blocks),
         }
-        ContentBlock::Thinking(_) | ContentBlock::RedactedThinking(_) => false,
+    }
+
+    fn assistant_msg(text: &str) -> MessageParam {
+        MessageParam {
+            role: MessageRole::Assistant,
+            content: MessageParamContent::String(text.to_string()),
+        }
+    }
+
+    fn count_message_cache_controls(messages: &[MessageParam]) -> usize {
+        let mut count = 0;
+        for msg in messages {
+            if let MessageParamContent::Array(blocks) = &msg.content {
+                for block in blocks {
+                    if let ContentBlock::Text(t) = block
+                        && t.cache_control.is_some()
+                    {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    fn system_has_cache_control(system: &Option<SystemPrompt>) -> bool {
+        match system {
+            Some(SystemPrompt::Blocks(blocks)) => blocks
+                .last()
+                .is_some_and(|b| b.block.cache_control.is_some()),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn no_system_no_messages() {
+        let mut system = None;
+        let mut messages: Vec<MessageParam> = vec![];
+        apply_cache_controls(&mut system, &mut messages);
+        assert!(!system_has_cache_control(&system));
+        assert_eq!(count_message_cache_controls(&messages), 0);
+    }
+
+    #[test]
+    fn system_prompt_gets_breakpoint() {
+        let mut system = Some(SystemPrompt::from_string("You are helpful.".to_string()));
+        let mut messages: Vec<MessageParam> = vec![];
+        apply_cache_controls(&mut system, &mut messages);
+        assert!(system_has_cache_control(&system));
+    }
+
+    #[test]
+    fn system_blocks_get_breakpoint_on_last() {
+        let blocks = vec![TextBlock::new("first"), TextBlock::new("second")];
+        let mut system = Some(SystemPrompt::from_blocks(blocks));
+        let mut messages: Vec<MessageParam> = vec![];
+        apply_cache_controls(&mut system, &mut messages);
+        if let Some(SystemPrompt::Blocks(blocks)) = &system {
+            assert!(blocks[0].block.cache_control.is_none());
+            assert!(blocks[1].block.cache_control.is_some());
+        } else {
+            panic!("Expected Blocks variant");
+        }
+    }
+
+    #[test]
+    fn fewer_than_20_blocks_gets_no_message_breakpoints() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages = vec![
+            user_msg_with_blocks(5, "u"),
+            assistant_msg("a"),
+            user_msg_with_blocks(5, "v"),
+        ];
+        apply_cache_controls(&mut system, &mut messages);
+        assert!(system_has_cache_control(&system));
+        assert_eq!(count_message_cache_controls(&messages), 0);
+    }
+
+    #[test]
+    fn exactly_20_blocks_gets_one_message_breakpoint() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages = vec![user_msg_with_blocks(20, "u")];
+        apply_cache_controls(&mut system, &mut messages);
+        assert!(system_has_cache_control(&system));
+        assert_eq!(count_message_cache_controls(&messages), 1);
+        if let MessageParamContent::Array(blocks) = &messages[0].content {
+            for (i, block) in blocks.iter().enumerate() {
+                if let ContentBlock::Text(t) = block {
+                    if i == 19 {
+                        assert!(
+                            t.cache_control.is_some(),
+                            "block 19 should have cache_control"
+                        );
+                    } else {
+                        assert!(
+                            t.cache_control.is_none(),
+                            "block {i} should not have cache_control"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn breakpoints_every_20_blocks() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages = vec![user_msg_with_blocks(45, "u")];
+        apply_cache_controls(&mut system, &mut messages);
+        assert_eq!(count_message_cache_controls(&messages), 2);
+        if let MessageParamContent::Array(blocks) = &messages[0].content {
+            for (i, block) in blocks.iter().enumerate() {
+                if let ContentBlock::Text(t) = block {
+                    if i == 19 || i == 39 {
+                        assert!(
+                            t.cache_control.is_some(),
+                            "block {i} should have cache_control"
+                        );
+                    } else {
+                        assert!(
+                            t.cache_control.is_none(),
+                            "block {i} should not have cache_control"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn exceeding_max_breakpoints_drops_earliest_message_breakpoints() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        // 80 blocks → candidates at 20, 40, 60, 80. Budget is 3.
+        // Drops the candidate at 20; keeps 40, 60, 80.
+        let mut messages = vec![user_msg_with_blocks(80, "u")];
+        apply_cache_controls(&mut system, &mut messages);
+        assert!(system_has_cache_control(&system));
+        assert_eq!(count_message_cache_controls(&messages), 3);
+        if let MessageParamContent::Array(blocks) = &messages[0].content {
+            for (i, block) in blocks.iter().enumerate() {
+                if let ContentBlock::Text(t) = block {
+                    if i == 39 || i == 59 || i == 79 {
+                        assert!(
+                            t.cache_control.is_some(),
+                            "block {i} should have cache_control"
+                        );
+                    } else {
+                        assert!(
+                            t.cache_control.is_none(),
+                            "block {i} should not have cache_control"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn clears_preexisting_markers() {
+        let mut system = Some(SystemPrompt::from_blocks(vec![
+            TextBlock::new("sys").with_cache_control(CacheControlEphemeral::new()),
+        ]));
+        let mut messages = vec![MessageParam {
+            role: MessageRole::User,
+            content: MessageParamContent::Array(vec![ContentBlock::Text(
+                TextBlock::new("stale marker").with_cache_control(CacheControlEphemeral::new()),
+            )]),
+        }];
+        apply_cache_controls(&mut system, &mut messages);
+        assert_eq!(count_message_cache_controls(&messages), 0);
+        assert!(system_has_cache_control(&system));
+    }
+
+    #[test]
+    fn breakpoints_span_multiple_messages() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        // 10 blocks in msg0, 1 assistant string, 15 blocks in msg2 → total 26 blocks.
+        // Breakpoint at counter 20: msg0 uses 10, msg1 uses 1 (counter=11), msg2 block 8 = counter 20.
+        let mut messages = vec![
+            user_msg_with_blocks(10, "a"),
+            assistant_msg("middle"),
+            user_msg_with_blocks(15, "b"),
+        ];
+        apply_cache_controls(&mut system, &mut messages);
+        assert_eq!(count_message_cache_controls(&messages), 1);
+        if let MessageParamContent::Array(blocks) = &messages[2].content {
+            for (i, block) in blocks.iter().enumerate() {
+                if let ContentBlock::Text(t) = block {
+                    if i == 8 {
+                        assert!(
+                            t.cache_control.is_some(),
+                            "block {i} of msg2 should have cache_control"
+                        );
+                    } else {
+                        assert!(t.cache_control.is_none(), "block {i} of msg2 should not");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn string_content_at_breakpoint_converts_to_array() {
+        let mut system = None;
+        let mut messages = vec![
+            user_msg_with_blocks(19, "u"),
+            MessageParam {
+                role: MessageRole::User,
+                content: MessageParamContent::String("twentieth".to_string()),
+            },
+        ];
+        apply_cache_controls(&mut system, &mut messages);
+        match &messages[1].content {
+            MessageParamContent::Array(blocks) => {
+                assert_eq!(blocks.len(), 1);
+                if let ContentBlock::Text(t) = &blocks[0] {
+                    assert_eq!(t.text, "twentieth");
+                    assert!(t.cache_control.is_some());
+                } else {
+                    panic!("Expected Text block");
+                }
+            }
+            MessageParamContent::String(_) => {
+                panic!("Expected conversion to Array");
+            }
+        }
+    }
+
+    #[test]
+    fn no_system_gives_full_budget_to_messages() {
+        let mut system = None;
+        // No system prompt → all MAX_MESSAGE_BREAKPOINTS available.
+        // 60 blocks → candidates at 20, 40, 60.  Budget = 3.  All fit.
+        let mut messages = vec![user_msg_with_blocks(60, "u")];
+        apply_cache_controls(&mut system, &mut messages);
+        assert_eq!(count_message_cache_controls(&messages), 3);
+    }
+
+    #[test]
+    fn stability_across_identical_calls() {
+        let mut system1 = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages1 = vec![
+            user_msg_with_blocks(15, "u"),
+            assistant_msg("a"),
+            user_msg_with_blocks(15, "v"),
+        ];
+        apply_cache_controls(&mut system1, &mut messages1);
+
+        let mut system2 = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages2 = vec![
+            user_msg_with_blocks(15, "u"),
+            assistant_msg("a"),
+            user_msg_with_blocks(15, "v"),
+        ];
+        apply_cache_controls(&mut system2, &mut messages2);
+
+        assert_eq!(system1, system2);
+        assert_eq!(messages1, messages2);
+    }
+
+    #[test]
+    fn stability_when_messages_grow() {
+        let mut system = Some(SystemPrompt::from_string("sys".to_string()));
+        let mut messages = vec![user_msg_with_blocks(25, "u")];
+        apply_cache_controls(&mut system, &mut messages);
+        println!(
+            "first_placement: {}",
+            count_message_cache_controls(&messages)
+        );
+        assert_eq!(count_message_cache_controls(&messages), 1);
+
+        // Append more blocks (total 31); breakpoint at 20 stays put.
+        messages.push(assistant_msg("a"));
+        messages.push(user_msg_with_blocks(5, "v"));
+        apply_cache_controls(&mut system, &mut messages);
+        println!(
+            "second_placement: {}",
+            count_message_cache_controls(&messages)
+        );
+        assert_eq!(count_message_cache_controls(&messages), 1);
+
+        if let MessageParamContent::Array(blocks) = &messages[0].content
+            && let ContentBlock::Text(t) = &blocks[19]
+        {
+            assert!(
+                t.cache_control.is_some(),
+                "block 19 should still have cache_control after growth"
+            );
+        }
+    }
+
+    #[test]
+    fn preexisting_system_blocks_cleared_before_reapply() {
+        let blocks = vec![
+            TextBlock::new("a").with_cache_control(CacheControlEphemeral::new()),
+            TextBlock::new("b").with_cache_control(CacheControlEphemeral::new()),
+        ];
+        let mut system = Some(SystemPrompt::from_blocks(blocks));
+        let mut messages: Vec<MessageParam> = vec![];
+        apply_cache_controls(&mut system, &mut messages);
+        if let Some(SystemPrompt::Blocks(blocks)) = &system {
+            assert!(
+                blocks[0].block.cache_control.is_none(),
+                "first block should be cleared"
+            );
+            assert!(
+                blocks[1].block.cache_control.is_some(),
+                "last block gets the breakpoint"
+            );
+        }
     }
 }

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -127,8 +127,7 @@ pub struct ChatConfig {
     pub session_budget: Option<Budget>,
     /// Path to persist transcripts automatically after each assistant turn.
     pub transcript_path: Option<PathBuf>,
-    /// Whether to enable prompt caching for the system prompt.
-    /// When enabled, the system prompt will include cache_control markers.
+    /// Whether prompt caching is enabled for this session.
     pub caching_enabled: bool,
 }
 

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -12,13 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_writer_pretty};
 
 use crate::Error;
-use crate::cache_control::apply_cache_control_to_messages;
 use crate::chat::config::ChatConfig;
 use crate::error::Result;
-use crate::types::{
-    CacheControlEphemeral, MessageCreateTemplate, MessageParam, Model, SystemPrompt, TextBlock,
-    Usage,
-};
+use crate::types::{MessageCreateTemplate, MessageParam, Model, SystemPrompt, Usage};
 use crate::{Agent, Anthropic, Budget, Renderer, ThinkingConfig, TurnOutcome};
 
 const BUDGET_BUFFER_MICRO_CENTS: u64 = 1;
@@ -64,22 +60,11 @@ impl Agent for ConfigAgent {
     }
 
     async fn system(&self) -> Option<SystemPrompt> {
-        let prompt = self.config.template.system.as_ref()?;
+        self.config.template.system.clone()
+    }
 
-        if self.config.caching_enabled {
-            let mut blocks = match prompt {
-                SystemPrompt::String(text) => vec![TextBlock::new(text.clone())],
-                SystemPrompt::Blocks(existing) => {
-                    existing.iter().map(|b| b.block.clone()).collect()
-                }
-            };
-            if let Some(last) = blocks.last_mut() {
-                last.cache_control = Some(CacheControlEphemeral::new());
-            }
-            Some(SystemPrompt::from_blocks(blocks))
-        } else {
-            Some(prompt.clone())
-        }
+    fn caching_enabled(&self) -> bool {
+        self.config.caching_enabled
     }
 
     async fn temperature(&self) -> Option<f32> {
@@ -221,11 +206,6 @@ impl<A: ChatAgent> ChatSession<A> {
 
         // Add user message to history
         self.messages.push(message);
-
-        // Apply cache_control markers to recent user messages if caching is enabled
-        if self.agent.config().caching_enabled {
-            apply_cache_control_to_messages(&mut self.messages);
-        }
 
         let outcome = self
             .agent
@@ -397,9 +377,8 @@ fn budget_allows_next_turn(budget: &Budget, last_turn_usage: Option<&Usage>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache_control::apply_cache_control_to_message;
+    use crate::MessageParamContent;
     use crate::types::{KnownModel, SystemPrompt};
-    use crate::{ContentBlock, MessageParamContent, MessageRole};
 
     #[test]
     fn new_session_empty() {
@@ -415,9 +394,8 @@ mod tests {
         let config = ChatConfig::default();
         let mut session = ChatSession::new(client, config);
 
-        // Manually add a message for testing
         session.messages.push(MessageParam {
-            role: MessageRole::User,
+            role: crate::MessageRole::User,
             content: MessageParamContent::String("test".to_string()),
         });
         assert_eq!(session.message_count(), 1);
@@ -480,225 +458,5 @@ mod tests {
         let budget = Budget::new_with_rates(100, 1, 1, 0, 0);
         let usage = Usage::new(100, 0);
         assert!(!budget_allows_next_turn(&budget, Some(&usage)));
-    }
-
-    #[test]
-    fn apply_cache_control_to_string_content() {
-        let mut message = MessageParam {
-            role: MessageRole::User,
-            content: MessageParamContent::String("hello".to_string()),
-        };
-
-        apply_cache_control_to_message(&mut message);
-
-        // Should have converted to array with cache_control
-        match &message.content {
-            MessageParamContent::Array(blocks) => {
-                assert_eq!(blocks.len(), 1);
-                if let ContentBlock::Text(text_block) = &blocks[0] {
-                    assert_eq!(text_block.text, "hello");
-                    assert!(text_block.cache_control.is_some());
-                } else {
-                    panic!("Expected Text block");
-                }
-            }
-            _ => panic!("Expected Array content"),
-        }
-    }
-
-    #[test]
-    fn apply_cache_control_to_array_content() {
-        let mut message = MessageParam {
-            role: MessageRole::User,
-            content: MessageParamContent::Array(vec![
-                ContentBlock::Text(TextBlock::new("first")),
-                ContentBlock::Text(TextBlock::new("second")),
-            ]),
-        };
-
-        apply_cache_control_to_message(&mut message);
-
-        // Should have cache_control only on the last block
-        match &message.content {
-            MessageParamContent::Array(blocks) => {
-                assert_eq!(blocks.len(), 2);
-                if let ContentBlock::Text(first) = &blocks[0] {
-                    assert!(first.cache_control.is_none());
-                }
-                if let ContentBlock::Text(second) = &blocks[1] {
-                    assert!(second.cache_control.is_some());
-                }
-            }
-            _ => panic!("Expected Array content"),
-        }
-    }
-
-    #[test]
-    fn apply_cache_control_to_messages_selects_user_messages() {
-        let mut messages = vec![
-            MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::String("user1".to_string()),
-            },
-            MessageParam {
-                role: MessageRole::Assistant,
-                content: MessageParamContent::String("assistant1".to_string()),
-            },
-            MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::String("user2".to_string()),
-            },
-            MessageParam {
-                role: MessageRole::Assistant,
-                content: MessageParamContent::String("assistant2".to_string()),
-            },
-            MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::String("user3".to_string()),
-            },
-        ];
-
-        apply_cache_control_to_messages(&mut messages);
-
-        // Should apply cache_control to last 3 user messages (MAX_CACHE_BREAKPOINTS - 1)
-        // User messages are at indices 0, 2, 4
-        for (idx, msg) in messages.iter().enumerate() {
-            let has_cache = match &msg.content {
-                MessageParamContent::Array(blocks) => blocks.last().is_some_and(|b| {
-                    if let ContentBlock::Text(t) = b {
-                        t.cache_control.is_some()
-                    } else {
-                        false
-                    }
-                }),
-                MessageParamContent::String(_) => false,
-            };
-
-            let is_user = msg.role == MessageRole::User;
-            // All user messages should have cache_control (we have 3 users, limit is 3)
-            if is_user {
-                assert!(
-                    has_cache,
-                    "User message at index {idx} should have cache_control"
-                );
-            } else {
-                // Assistant messages should not be modified
-                assert!(
-                    !has_cache,
-                    "Assistant message at index {idx} should not have cache_control"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn apply_cache_control_respects_max_breakpoints() {
-        // Create 5 user messages - only last 3 should get cache_control
-        let mut messages: Vec<MessageParam> = (0..5)
-            .map(|i| MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::String(format!("user{i}")),
-            })
-            .collect();
-
-        apply_cache_control_to_messages(&mut messages);
-
-        let cached_count = messages
-            .iter()
-            .filter(|msg| {
-                matches!(
-                    &msg.content,
-                    MessageParamContent::Array(blocks)
-                    if blocks.last().is_some_and(|b| {
-                        matches!(b, ContentBlock::Text(t) if t.cache_control.is_some())
-                    })
-                )
-            })
-            .count();
-
-        // MAX_CACHE_BREAKPOINTS - 1 = 3
-        assert_eq!(cached_count, 3);
-
-        // Verify it's the LAST 3 messages that got cache_control
-        for (idx, msg) in messages.iter().enumerate() {
-            let has_cache = matches!(
-                &msg.content,
-                MessageParamContent::Array(blocks)
-                if blocks.last().is_some_and(|b| {
-                    matches!(b, ContentBlock::Text(t) if t.cache_control.is_some())
-                })
-            );
-
-            if idx < 2 {
-                assert!(!has_cache, "Message {idx} should NOT have cache_control");
-            } else {
-                assert!(has_cache, "Message {idx} should have cache_control");
-            }
-        }
-    }
-
-    #[test]
-    fn apply_cache_control_clears_old_markers() {
-        // Simulate a conversation that grows over multiple turns.
-        // Initially we have 3 user messages with cache_control set on all of them.
-        let mut messages: Vec<MessageParam> = (0..3)
-            .map(|i| MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::Array(vec![ContentBlock::Text(
-                    TextBlock::new(format!("user{i}"))
-                        .with_cache_control(CacheControlEphemeral::new()),
-                )]),
-            })
-            .collect();
-
-        // Add 2 more user messages (simulating additional turns)
-        for i in 3..5 {
-            messages.push(MessageParam {
-                role: MessageRole::User,
-                content: MessageParamContent::String(format!("user{i}")),
-            });
-        }
-
-        // At this point, messages 0, 1, 2 have cache_control from before.
-        // After apply_cache_control_to_messages, only the last 3 (2, 3, 4) should have it.
-        apply_cache_control_to_messages(&mut messages);
-
-        let cached_count = messages
-            .iter()
-            .filter(|msg| {
-                matches!(
-                    &msg.content,
-                    MessageParamContent::Array(blocks)
-                    if blocks.last().is_some_and(|b| {
-                        matches!(b, ContentBlock::Text(t) if t.cache_control.is_some())
-                    })
-                )
-            })
-            .count();
-
-        // Only 3 messages should have cache_control (MAX_CACHE_BREAKPOINTS - 1)
-        // DEBUG: Print cached count
-        println!("cached_count: {cached_count}");
-        assert_eq!(cached_count, 3, "Only 3 messages should have cache_control");
-
-        // Verify the FIRST 2 messages no longer have cache_control (they were cleared)
-        for (idx, msg) in messages.iter().enumerate() {
-            let has_cache = matches!(
-                &msg.content,
-                MessageParamContent::Array(blocks)
-                if blocks.last().is_some_and(|b| {
-                    matches!(b, ContentBlock::Text(t) if t.cache_control.is_some())
-                })
-            );
-
-            if idx < 2 {
-                assert!(
-                    !has_cache,
-                    "Message {idx} should have cache_control CLEARED"
-                );
-            } else {
-                assert!(has_cache, "Message {idx} should have cache_control");
-            }
-        }
     }
 }


### PR DESCRIPTION
Replace scattered cache_control logic with a single deterministic entry
point — apply_cache_controls — that clears all existing markers and
places breakpoints by content-block position rather than by targeting
the last N user messages.  Position-based placement produces stable
prefix hashes across requests, improving cache hit rates.

- Add Agent::caching_enabled() trait method (default false)
- Call apply_cache_controls from create_params when caching is on
- Remove per-tool-result cache_control markers and pruning
- Remove apply_cache_control_to_messages and related session logic
- Add comprehensive tests for the new placement strategy

Co-authored-by: AI
