### PR TITLE
feat(model): add Claude Opus 4.7 known model

### DIFF
--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -63,6 +63,9 @@ pub enum KnownModel {
     /// Claude Opus 4.1 (2025-08-05 version)
     ClaudeOpus4120250805,
 
+    /// Claude Opus 4.7 (alias)
+    ClaudeOpus47,
+
     /// Claude 3 Opus (latest version)
     Claude3OpusLatest,
 
@@ -100,6 +103,7 @@ impl fmt::Display for KnownModel {
             KnownModel::ClaudeOpus420250514 => write!(f, "claude-opus-4-20250514"),
             KnownModel::Claude4Opus20250514 => write!(f, "claude-4-opus-20250514"),
             KnownModel::ClaudeOpus4120250805 => write!(f, "claude-opus-4-1-20250805"),
+            KnownModel::ClaudeOpus47 => write!(f, "claude-opus-4-7"),
             KnownModel::Claude3OpusLatest => write!(f, "claude-3-opus-latest"),
             KnownModel::Claude3Opus20240229 => write!(f, "claude-3-opus-20240229"),
             KnownModel::Claude3Haiku20240307 => write!(f, "claude-3-haiku-20240307"),
@@ -141,6 +145,7 @@ impl<'de> Deserialize<'de> for Model {
             "claude-opus-4-20250514" => Ok(Model::Known(KnownModel::ClaudeOpus420250514)),
             "claude-4-opus-20250514" => Ok(Model::Known(KnownModel::Claude4Opus20250514)),
             "claude-opus-4-1-20250805" => Ok(Model::Known(KnownModel::ClaudeOpus4120250805)),
+            "claude-opus-4-7" => Ok(Model::Known(KnownModel::ClaudeOpus47)),
             "claude-3-opus-latest" => Ok(Model::Known(KnownModel::Claude3OpusLatest)),
             "claude-3-opus-20240229" => Ok(Model::Known(KnownModel::Claude3Opus20240229)),
             "claude-3-haiku-20240307" => Ok(Model::Known(KnownModel::Claude3Haiku20240307)),
@@ -176,6 +181,7 @@ impl FromStr for KnownModel {
             "claude-opus-4-20250514" => Ok(KnownModel::ClaudeOpus420250514),
             "claude-4-opus-20250514" => Ok(KnownModel::Claude4Opus20250514),
             "claude-opus-4-1-20250805" => Ok(KnownModel::ClaudeOpus4120250805),
+            "claude-opus-4-7" => Ok(KnownModel::ClaudeOpus47),
             "claude-3-opus-latest" => Ok(KnownModel::Claude3OpusLatest),
             "claude-3-opus-20240229" => Ok(KnownModel::Claude3Opus20240229),
             "claude-3-haiku-20240307" => Ok(KnownModel::Claude3Haiku20240307),
@@ -250,6 +256,10 @@ mod tests {
         let model = Model::Known(KnownModel::ClaudeOpus4120250805);
         assert_eq!(model.to_string(), "claude-opus-4-1-20250805");
 
+        // Test Claude Opus 4.7
+        let model = Model::Known(KnownModel::ClaudeOpus47);
+        assert_eq!(model.to_string(), "claude-opus-4-7");
+
         // Test deserialization of Claude 4 models
         let json = r#""claude-sonnet-4-20250514""#;
         let model: Model = serde_json::from_str(json).unwrap();
@@ -262,6 +272,10 @@ mod tests {
         let json = r#""claude-opus-4-1-20250805""#;
         let model: Model = serde_json::from_str(json).unwrap();
         assert_eq!(model, Model::Known(KnownModel::ClaudeOpus4120250805));
+
+        let json = r#""claude-opus-4-7""#;
+        let model: Model = serde_json::from_str(json).unwrap();
+        assert_eq!(model, Model::Known(KnownModel::ClaudeOpus47));
     }
 
     #[test]


### PR DESCRIPTION
Add ClaudeOpus47 variant to KnownModel for "claude-opus-4-7" with
Display, Deserialize, and FromStr implementations plus tests.

Co-authored-by: AI
