### PR TITLE
chore: bump version to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ tokio = { version = "^1.49", features = ["full"] }
 tokio-util = { version = "^0.7", features = ["codec"] }
 url = "2.5"
 
-arrrg = "^0.8"
-arrrg_derive = "^0.8"
-biometrics = "^0.12"
-utf8path = "^0.9"
+arrrg = "^0.9"
+arrrg_derive = "^0.9"
+biometrics = "^0.13"
+utf8path = "^0.10"
 
 [[bin]]
 name = "median-text"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2024"
 description = "SDK for the Anthropic API"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claudius
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)
-![Version](https://img.shields.io/badge/version-0.24.0-green.svg)
+![Version](https://img.shields.io/badge/version-0.25.0-green.svg)
 
 Claudius is a comprehensive Rust SDK for the Anthropic API, providing both low-level API access and a 
 powerful agent framework for building AI-powered applications. This library enables seamless integration 
@@ -73,7 +73,7 @@ Add Claudius to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-claudius = "0.24.0"
+claudius = "0.25.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
Update version from 0.24.0 to 0.25.0 in Cargo.toml, README badge,
and README install instructions.

Co-authored-by: AI
