### PR TITLE
fix: remove duplicate serde type tags from result blocks

### DIFF
--- a/src/types/message_create_params.rs
+++ b/src/types/message_create_params.rs
@@ -639,7 +639,9 @@ impl Default for MessageCreateParams {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Effort, KnownModel, MessageRole, OutputConfig};
+    use crate::types::{
+        ContentBlock, Effort, KnownModel, MessageRole, OutputConfig, ToolResultBlock,
+    };
     use serde_json::{json, to_value};
 
     #[test]
@@ -902,5 +904,43 @@ mod tests {
             .with_output_config(OutputConfig::new().with_effort(Effort::High));
 
         assert!(params.output_config.is_some());
+    }
+
+    #[test]
+    fn message_create_params_serializes_tool_result_messages_without_duplicate_type() {
+        let message = MessageParam::new_with_blocks(
+            vec![ContentBlock::ToolResult(
+                ToolResultBlock::new("toolu_123".to_string()).with_string_content("ok".to_string()),
+            )],
+            MessageRole::User,
+        );
+
+        let params = MessageCreateParams::new(
+            1000,
+            vec![message],
+            Model::Known(KnownModel::Claude37Sonnet20250219),
+        );
+
+        let json = to_value(&params).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "max_tokens": 1000,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_123",
+                                "content": "ok"
+                            }
+                        ]
+                    }
+                ],
+                "model": "claude-3-7-sonnet-20250219",
+                "stream": false
+            })
+        );
     }
 }

--- a/src/types/message_param.rs
+++ b/src/types/message_param.rs
@@ -88,7 +88,10 @@ impl<T: AsRef<str>> From<T> for MessageParamContent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ImageBlock, KnownModel, Message, Model, TextBlock, Usage};
+    use crate::types::{
+        ImageBlock, KnownModel, Message, Model, TextBlock, ToolResultBlock, Usage,
+        WebSearchResultBlock, WebSearchToolResultBlock, WebSearchToolResultBlockContent,
+    };
     use serde_json::{json, to_value};
 
     #[test]
@@ -267,5 +270,92 @@ mod tests {
             }
             _ => panic!("Expected Array variant"),
         }
+    }
+
+    #[test]
+    fn message_param_deserializes_tool_result_transcript_blocks() {
+        let transcript = json!([
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_123",
+                        "content": "ok"
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "toolu_456",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "encrypted_content": "encrypted-data-1",
+                                "title": "Example Page 1",
+                                "url": "https://example.com/page1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]);
+
+        let messages: Vec<MessageParam> = serde_json::from_value(transcript).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        let MessageParamContent::Array(blocks) = &messages[0].content else {
+            panic!("Expected array content");
+        };
+        assert!(matches!(&blocks[0], ContentBlock::ToolResult(_)));
+        assert!(matches!(&blocks[1], ContentBlock::WebSearchToolResult(_)));
+    }
+
+    #[test]
+    fn message_param_serializes_tool_result_transcript_blocks_without_duplicate_type() {
+        let tool_result =
+            ToolResultBlock::new("toolu_123".to_string()).with_string_content("ok".to_string());
+        let search_result = WebSearchResultBlock::new(
+            "encrypted-data-1",
+            "Example Page 1",
+            "https://example.com/page1",
+        );
+        let web_search_tool_result = WebSearchToolResultBlock::new(
+            WebSearchToolResultBlockContent::with_results(vec![search_result]),
+            "toolu_456",
+        );
+
+        let message = MessageParam::new_with_blocks(
+            vec![
+                ContentBlock::ToolResult(tool_result),
+                ContentBlock::WebSearchToolResult(web_search_tool_result),
+            ],
+            MessageRole::User,
+        );
+
+        let json = to_value(&message).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_123",
+                        "content": "ok"
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "toolu_456",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "encrypted_content": "encrypted-data-1",
+                                "title": "Example Page 1",
+                                "url": "https://example.com/page1"
+                            }
+                        ]
+                    }
+                ]
+            })
+        );
     }
 }

--- a/src/types/tool_result_block.rs
+++ b/src/types/tool_result_block.rs
@@ -8,8 +8,6 @@ use crate::types::{CacheControlEphemeral, Content};
 /// requested via a ToolUseBlock. It contains the tool's response, which can be
 /// either successful output or an error indication.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type")]
-#[serde(rename = "tool_result")]
 pub struct ToolResultBlock {
     /// The ID of the tool use that this result is for.
     ///
@@ -118,19 +116,21 @@ impl ToolResultBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ContentBlock;
     use serde_json::{json, to_value};
 
     #[test]
     fn tool_result_block_with_string_content() {
         let block = ToolResultBlock::new("tool_1".to_string())
             .with_string_content("Result of tool execution".to_string());
+        let content_block = ContentBlock::ToolResult(block);
 
-        let json = to_value(&block).unwrap();
+        let json = to_value(&content_block).unwrap();
         assert_eq!(
             json,
             json!({
-                "tool_use_id": "tool_1",
                 "type": "tool_result",
+                "tool_use_id": "tool_1",
                 "content": "Result of tool execution"
             })
         );
@@ -142,13 +142,14 @@ mod tests {
         let content = vec![Content::Text(text_param)];
 
         let block = ToolResultBlock::new("tool_1".to_string()).with_array_content(content);
+        let content_block = ContentBlock::ToolResult(block);
 
-        let json = to_value(&block).unwrap();
+        let json = to_value(&content_block).unwrap();
         assert_eq!(
             json,
             json!({
-                "tool_use_id": "tool_1",
                 "type": "tool_result",
+                "tool_use_id": "tool_1",
                 "content": [
                     {
                         "text": "Sample text content",
@@ -164,13 +165,14 @@ mod tests {
         let block = ToolResultBlock::new("tool_1".to_string())
             .with_string_content("Error executing tool".to_string())
             .with_error(true);
+        let content_block = ContentBlock::ToolResult(block);
 
-        let json = to_value(&block).unwrap();
+        let json = to_value(&content_block).unwrap();
         assert_eq!(
             json,
             json!({
-                "tool_use_id": "tool_1",
                 "type": "tool_result",
+                "tool_use_id": "tool_1",
                 "content": "Error executing tool",
                 "is_error": true
             })
@@ -180,13 +182,16 @@ mod tests {
     #[test]
     fn tool_result_block_deserialization() {
         let json = json!({
-            "tool_use_id": "tool_1",
             "type": "tool_result",
+            "tool_use_id": "tool_1",
             "content": "Result of tool execution",
             "is_error": false
         });
 
-        let block: ToolResultBlock = serde_json::from_value(json).unwrap();
+        let block: ContentBlock = serde_json::from_value(json).unwrap();
+        let ContentBlock::ToolResult(block) = block else {
+            panic!("Expected ToolResult variant");
+        };
         assert_eq!(block.tool_use_id, "tool_1");
 
         match &block.content {

--- a/src/types/web_search_tool_result_block.rs
+++ b/src/types/web_search_tool_result_block.rs
@@ -6,8 +6,6 @@ use crate::types::{CacheControlEphemeral, WebSearchToolResultBlockContent};
 ///
 /// WebSearchToolResultBlock contains either a list of search results or an error.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type")]
-#[serde(rename = "web_search_tool_result")]
 pub struct WebSearchToolResultBlock {
     /// The content of the web search tool result.
     pub content: WebSearchToolResultBlockContent,
@@ -77,7 +75,9 @@ impl WebSearchToolResultBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{WebSearchErrorCode, WebSearchResultBlock, WebSearchToolResultError};
+    use crate::types::{
+        ContentBlock, WebSearchErrorCode, WebSearchResultBlock, WebSearchToolResultError,
+    };
     use serde_json::Value;
 
     #[test]
@@ -93,8 +93,9 @@ mod tests {
 
         let content = WebSearchToolResultBlockContent::with_results(results);
         let block = WebSearchToolResultBlock::new(content, "tool-123");
+        let content_block = ContentBlock::WebSearchToolResult(block);
 
-        let json = serde_json::to_string(&block).unwrap();
+        let json = serde_json::to_string(&content_block).unwrap();
 
         // Parse both the actual and expected JSON to Values for comparison
         // This avoids issues with key ordering
@@ -114,8 +115,9 @@ mod tests {
 
         let content = WebSearchToolResultBlockContent::with_error(error);
         let block = WebSearchToolResultBlock::new(content, "tool-123");
+        let content_block = ContentBlock::WebSearchToolResult(block);
 
-        let json = serde_json::to_string(&block).unwrap();
+        let json = serde_json::to_string(&content_block).unwrap();
 
         // Parse both the actual and expected JSON to Values for comparison
         let actual: Value = serde_json::from_str(&json).unwrap();
@@ -129,7 +131,10 @@ mod tests {
     #[test]
     fn deserialization() {
         let json = r#"{"content":[{"type":"web_search_result","encrypted_content":"encrypted-data-1","page_age":"2 days ago","title":"Example Page 1","url":"https://example.com/page1"}],"tool_use_id":"tool-123","type":"web_search_tool_result"}"#;
-        let block: WebSearchToolResultBlock = serde_json::from_str(json).unwrap();
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        let ContentBlock::WebSearchToolResult(block) = block else {
+            panic!("Expected WebSearchToolResult variant");
+        };
 
         assert_eq!(block.tool_use_id, "tool-123");
         assert!(block.has_results());


### PR DESCRIPTION
Remove #[serde(tag = "type")] and #[serde(rename = "...")] from
ToolResultBlock and WebSearchToolResultBlock. These structs are
serialized as variants of the ContentBlock enum, which already applies
the type tag via its own serde configuration. The duplicate tag
attributes caused a "type" field to appear twice in serialized JSON,
which is invalid.

Update existing tests to serialize and deserialize through
ContentBlock rather than directly on the inner structs, matching how
these types are used in practice. Add new tests in message_param and
message_create_params that verify round-trip serialization of tool
result content blocks produces correct JSON without duplicate type
fields.

Co-authored-by: AI
