### PR TITLE
feat: add adaptive thinking and effort level support

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,9 +16,9 @@ use crate::observability::{
 use crate::{
     AccumulatingStream, AgentStreamContext, Anthropic, CacheControlEphemeral, ContentBlock,
     ContentBlockDelta, Error, KnownModel, Message, MessageCreateParams, MessageParam,
-    MessageParamContent, MessageRole, MessageStreamEvent, Metadata, Model, Renderer, StopReason,
-    StreamContext, SystemPrompt, ThinkingConfig, ToolBash20241022, ToolBash20250124, ToolChoice,
-    ToolParam, ToolResultBlock, ToolResultBlockContent, ToolTextEditor20250124,
+    MessageParamContent, MessageRole, MessageStreamEvent, Metadata, Model, OutputConfig, Renderer,
+    StopReason, StreamContext, SystemPrompt, ThinkingConfig, ToolBash20241022, ToolBash20250124,
+    ToolChoice, ToolParam, ToolResultBlock, ToolResultBlockContent, ToolTextEditor20250124,
     ToolTextEditor20250429, ToolTextEditor20250728, ToolUnionParam, ToolUseBlock, Usage,
     WebSearchTool20250305, push_or_merge_message,
 };
@@ -1629,6 +1629,13 @@ pub trait Agent: Send + Sync + Sized {
         None
     }
 
+    /// Returns the output configuration for requests.
+    ///
+    /// This is used to pass effort levels for adaptive thinking via `OutputConfig`.
+    async fn output_config(&self) -> Option<OutputConfig> {
+        None
+    }
+
     /// Returns the filesystem implementation for this agent.
     async fn filesystem(&self) -> Option<&dyn FileSystem> {
         None
@@ -2012,7 +2019,7 @@ pub trait Agent: Send + Sync + Sized {
             },
             metadata: self.metadata().await,
             output_format: None,
-            output_config: None,
+            output_config: self.output_config().await,
             stop_sequences: self.stop_sequences().await,
             system,
             thinking: self.thinking().await,

--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -42,7 +42,7 @@ use claudius::chat::{
     ChatAgent, ChatArgs, ChatCommand, ChatConfig, ChatSession, PlainTextRenderer, help_text,
     parse_command,
 };
-use claudius::{Anthropic, Model, StopReason, SystemPrompt, ThinkingConfig};
+use claudius::{Anthropic, Effort, Model, StopReason, SystemPrompt, ThinkingConfig};
 use claudius::{OperatorLine, Renderer, StreamContext};
 
 struct ChatTerminal {
@@ -266,7 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             print_stop_sequences(sequences);
                         }
                         ChatCommand::Thinking(budget) => {
-                            session.template_mut().thinking = budget.map(ThinkingConfig::enabled);
+                            session.config_mut().set_thinking_budget(budget);
                             match budget {
                                 Some(tokens) => {
                                     terminal.print_info(
@@ -281,6 +281,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     terminal.print_info(&context, "Extended thinking disabled.");
                                 }
                             }
+                        }
+                        ChatCommand::ThinkingAdaptive => {
+                            let effort = session.config().effort();
+                            session.config_mut().set_thinking_adaptive(effort);
+                            terminal.print_info(&context, "Adaptive thinking enabled.");
+                        }
+                        ChatCommand::Effort(effort) => {
+                            session.config_mut().set_effort(Some(effort));
+                            let label = match effort {
+                                Effort::Low => "low",
+                                Effort::Medium => "medium",
+                                Effort::High => "high",
+                            };
+                            terminal.print_info(
+                                &context,
+                                &format!("Effort level set to {label}."),
+                            );
+                        }
+                        ChatCommand::ClearEffort => {
+                            session.config_mut().set_effort(None);
+                            terminal.print_info(&context, "Effort level cleared.");
                         }
                         ChatCommand::Budget(_tokens) => {
                             terminal.print_error(&context, "budget not supported");
@@ -384,13 +405,7 @@ fn print_stats<A: ChatAgent>(session: &ChatSession<A>) {
     } else {
         println!("      System prompt: (none)");
     }
-    println!(
-        "      Thinking: {}",
-        match stats.thinking_budget {
-            Some(budget) => format!("enabled ({} tokens)", budget),
-            None => "disabled".to_string(),
-        }
-    );
+    println!("      Thinking: {}", describe_thinking(&stats));
     print_stop_sequences(&stats.stop_sequences);
     println!(
         "      Total tokens: {} in / {} out ({} requests)",
@@ -429,13 +444,7 @@ fn print_config<A: ChatAgent>(session: &ChatSession<A>) {
     println!("      Temperature: {}", describe_float(stats.temperature));
     println!("      Top-p: {}", describe_float(stats.top_p));
     println!("      Top-k: {}", describe_top_k(stats.top_k));
-    println!(
-        "      Thinking: {}",
-        match stats.thinking_budget {
-            Some(budget) => format!("enabled ({} tokens)", budget),
-            None => "disabled".to_string(),
-        }
-    );
+    println!("      Thinking: {}", describe_thinking(&stats));
     println!(
         "      Caching: {}",
         if stats.caching_enabled {
@@ -464,6 +473,26 @@ fn print_stop_sequences(stop_sequences: &[String]) {
         for seq in stop_sequences {
             println!("        - {}", seq);
         }
+    }
+}
+
+fn describe_thinking(stats: &claudius::chat::SessionStats) -> String {
+    match stats.thinking_config {
+        Some(ThinkingConfig::Adaptive) => {
+            let effort = stats
+                .effort
+                .map(|e| match e {
+                    Effort::Low => "low",
+                    Effort::Medium => "medium",
+                    Effort::High => "high",
+                })
+                .unwrap_or("default");
+            format!("adaptive (effort: {effort})")
+        }
+        Some(ThinkingConfig::Enabled { budget_tokens }) => {
+            format!("enabled ({budget_tokens} tokens)")
+        }
+        Some(ThinkingConfig::Disabled) | None => "disabled".to_string(),
     }
 }
 

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -53,6 +53,15 @@ pub enum ChatCommand {
     /// `None` disables thinking, `Some(budget)` enables with the given token budget.
     Thinking(Option<u32>),
 
+    /// Enable adaptive thinking (with default or current effort level).
+    ThinkingAdaptive,
+
+    /// Set the effort level for adaptive thinking.
+    Effort(crate::types::Effort),
+
+    /// Clear the effort level.
+    ClearEffort,
+
     /// Set a per-session token budget.
     Budget(u64),
 
@@ -152,6 +161,7 @@ pub fn parse_command(input: &str) -> Option<ChatCommand> {
         },
         "stop" => parse_stop_command(argument),
         "thinking" => parse_thinking_command(argument),
+        "effort" => parse_effort_command(argument),
         "budget" => match argument {
             Some(arg) if arg.eq_ignore_ascii_case("clear") => ChatCommand::ClearBudget,
             Some(arg) => match arg.parse::<u64>() {
@@ -236,7 +246,7 @@ const DEFAULT_THINKING_BUDGET: u32 = 1024;
 fn parse_thinking_command(argument: Option<&str>) -> ChatCommand {
     let Some(arg) = argument else {
         return ChatCommand::Invalid(
-            "/thinking expects 'on', 'off', or a token budget (e.g., 2048)".to_string(),
+            "/thinking expects 'on', 'off', 'adaptive', or a token budget (e.g., 2048)".to_string(),
         );
     };
 
@@ -244,12 +254,33 @@ fn parse_thinking_command(argument: Option<&str>) -> ChatCommand {
     match lower.as_str() {
         "off" | "false" | "no" => ChatCommand::Thinking(None),
         "on" | "true" | "yes" => ChatCommand::Thinking(Some(DEFAULT_THINKING_BUDGET)),
+        "adaptive" => ChatCommand::ThinkingAdaptive,
         _ => match arg.parse::<u32>() {
             Ok(budget) => ChatCommand::Thinking(Some(budget)),
             Err(_) => ChatCommand::Invalid(
-                "/thinking expects 'on', 'off', or a token budget (e.g., 2048)".to_string(),
+                "/thinking expects 'on', 'off', 'adaptive', or a token budget (e.g., 2048)"
+                    .to_string(),
             ),
         },
+    }
+}
+
+fn parse_effort_command(argument: Option<&str>) -> ChatCommand {
+    let Some(arg) = argument else {
+        return ChatCommand::Invalid(
+            "/effort expects 'low', 'medium', 'high', or 'clear'".to_string(),
+        );
+    };
+
+    let lower = arg.to_lowercase();
+    match lower.as_str() {
+        "low" => ChatCommand::Effort(crate::types::Effort::Low),
+        "medium" | "med" => ChatCommand::Effort(crate::types::Effort::Medium),
+        "high" => ChatCommand::Effort(crate::types::Effort::High),
+        "clear" | "off" | "none" => ChatCommand::ClearEffort,
+        _ => ChatCommand::Invalid(
+            "/effort expects 'low', 'medium', 'high', or 'clear'".to_string(),
+        ),
     }
 }
 
@@ -279,7 +310,8 @@ pub fn help_text() -> &'static str {
   /stop add <seq>        Add a stop sequence
   /stop clear            Clear all stop sequences
   /stop list             List current stop sequences
-  /thinking on|off|<n>   Enable/disable extended thinking (or set budget)
+  /thinking on|off|adaptive|<n>  Enable/disable extended thinking (or set budget)
+  /effort low|medium|high|clear  Set effort level for adaptive thinking
   /cache on|off          Enable/disable prompt caching
   /budget <tokens>       Set total session budget (or 'clear')
   /transcript <file>     Enable auto-saving transcripts (or 'clear')
@@ -384,8 +416,48 @@ mod tests {
             parse_command("/thinking 2048"),
             Some(ChatCommand::Thinking(Some(2048)))
         );
+        assert_eq!(
+            parse_command("/thinking adaptive"),
+            Some(ChatCommand::ThinkingAdaptive)
+        );
         assert!(matches!(
             parse_command("/thinking maybe"),
+            Some(ChatCommand::Invalid(msg)) if msg.contains("expects")
+        ));
+    }
+
+    #[test]
+    fn parse_effort_levels() {
+        assert_eq!(
+            parse_command("/effort low"),
+            Some(ChatCommand::Effort(crate::types::Effort::Low))
+        );
+        assert_eq!(
+            parse_command("/effort medium"),
+            Some(ChatCommand::Effort(crate::types::Effort::Medium))
+        );
+        assert_eq!(
+            parse_command("/effort med"),
+            Some(ChatCommand::Effort(crate::types::Effort::Medium))
+        );
+        assert_eq!(
+            parse_command("/effort high"),
+            Some(ChatCommand::Effort(crate::types::Effort::High))
+        );
+        assert_eq!(
+            parse_command("/effort clear"),
+            Some(ChatCommand::ClearEffort)
+        );
+        assert_eq!(
+            parse_command("/effort off"),
+            Some(ChatCommand::ClearEffort)
+        );
+        assert!(matches!(
+            parse_command("/effort"),
+            Some(ChatCommand::Invalid(msg)) if msg.contains("expects")
+        ));
+        assert!(matches!(
+            parse_command("/effort whatever"),
             Some(ChatCommand::Invalid(msg)) if msg.contains("expects")
         ));
     }

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -8,7 +8,20 @@ use std::path::PathBuf;
 use arrrg_derive::CommandLine;
 
 use crate::Budget;
-use crate::types::{KnownModel, MessageCreateTemplate, Model, SystemPrompt, ThinkingConfig};
+use crate::types::{
+    Effort, KnownModel, MessageCreateTemplate, Model, OutputConfig, SystemPrompt, ThinkingConfig,
+};
+
+/// The resolved thinking mode for a chat session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingMode {
+    /// Thinking is disabled.
+    Disabled,
+    /// Adaptive thinking with an effort level.
+    Adaptive(Effort),
+    /// Extended thinking with a fixed token budget.
+    Budgeted(u32),
+}
 
 /// Default maximum tokens per response.
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -48,6 +61,10 @@ pub struct ChatArgs {
     )]
     pub thinking: Option<u32>,
 
+    /// Effort level for adaptive thinking (low, medium, high).
+    #[arrrg(optional, "Effort level for adaptive thinking (low, medium, high)", "LEVEL")]
+    pub effort: Option<String>,
+
     /// Disable ANSI colors and styles.
     #[arrrg(flag, "Disable ANSI colors/styles")]
     pub no_color: bool,
@@ -74,6 +91,20 @@ fn parse_f32_arg(value: &str, name: &str) -> Result<f32, ChatArgsError> {
             name, value
         ),
     })
+}
+
+fn parse_effort(s: &str) -> Result<Effort, ChatArgsError> {
+    match s.to_lowercase().as_str() {
+        "low" => Ok(Effort::Low),
+        "medium" | "med" => Ok(Effort::Medium),
+        "high" => Ok(Effort::High),
+        _ => Err(ChatArgsError {
+            message: format!(
+                "invalid value for --effort: '{}' (expected low, medium, or high)",
+                s
+            ),
+        }),
+    }
 }
 
 impl TryFrom<ChatArgs> for MessageCreateTemplate {
@@ -105,6 +136,12 @@ impl TryFrom<ChatArgs> for MessageCreateTemplate {
 
         template.top_k = args.top_k;
 
+        if let Some(ref effort_str) = args.effort {
+            let effort = parse_effort(effort_str)?;
+            template.thinking = Some(ThinkingConfig::Adaptive);
+            template.output_config = Some(OutputConfig::new().with_effort(effort));
+        }
+
         if let Some(thinking) = args.thinking {
             template.thinking = Some(ThinkingConfig::enabled(thinking));
         }
@@ -129,6 +166,8 @@ pub struct ChatConfig {
     pub transcript_path: Option<PathBuf>,
     /// Whether prompt caching is enabled for this session.
     pub caching_enabled: bool,
+    /// Optional effort level for adaptive thinking.
+    pub effort: Option<Effort>,
 }
 
 impl ChatConfig {
@@ -147,6 +186,7 @@ impl ChatConfig {
             session_budget: None,
             transcript_path: None,
             caching_enabled: true,
+            effort: None,
         }
     }
 
@@ -200,8 +240,26 @@ impl ChatConfig {
 
     /// Sets the thinking budget.
     /// `None` disables thinking, `Some(budget)` enables with the given token budget.
+    /// Clears any adaptive effort setting to avoid conflicting modes.
     pub fn with_thinking_budget(mut self, budget: Option<u32>) -> Self {
         self.template.thinking = budget.map(ThinkingConfig::enabled);
+        self.template.output_config = None;
+        self.effort = None;
+        self
+    }
+
+    /// Sets adaptive thinking with an optional effort level.
+    pub fn with_thinking_adaptive(mut self, effort: Option<Effort>) -> Self {
+        self.template.thinking = Some(ThinkingConfig::Adaptive);
+        self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
+        self.effort = effort;
+        self
+    }
+
+    /// Sets the effort level for adaptive thinking.
+    pub fn with_effort(mut self, effort: Option<Effort>) -> Self {
+        self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
+        self.effort = effort;
         self
     }
 
@@ -257,6 +315,38 @@ impl ChatConfig {
         }
     }
 
+    /// Returns the full thinking configuration, if any.
+    ///
+    /// Use this to distinguish `Adaptive` from `Enabled { budget_tokens }`
+    /// from `None`/`Disabled`.
+    pub fn thinking_config(&self) -> Option<ThinkingConfig> {
+        self.template.thinking
+    }
+
+    /// Returns the resolved thinking mode.
+    pub fn thinking_mode(&self) -> ThinkingMode {
+        match self.template.thinking {
+            Some(ThinkingConfig::Adaptive) => {
+                ThinkingMode::Adaptive(self.effort.unwrap_or(Effort::Medium))
+            }
+            Some(ThinkingConfig::Enabled { budget_tokens }) => {
+                ThinkingMode::Budgeted(budget_tokens)
+            }
+            Some(ThinkingConfig::Disabled) | None => ThinkingMode::Disabled,
+        }
+    }
+
+    /// Returns the configured effort level, if any.
+    pub fn effort(&self) -> Option<Effort> {
+        self.effort
+    }
+
+    /// Builds the `OutputConfig` for this session, if effort is set.
+    pub fn output_config(&self) -> Option<OutputConfig> {
+        self.effort
+            .map(|effort| OutputConfig::new().with_effort(effort))
+    }
+
     /// Sets the model.
     pub fn set_model(&mut self, model: Model) {
         self.template.model = Some(model);
@@ -288,8 +378,24 @@ impl ChatConfig {
     }
 
     /// Sets the thinking budget.
+    /// Clears any adaptive effort setting to avoid conflicting modes.
     pub fn set_thinking_budget(&mut self, budget: Option<u32>) {
         self.template.thinking = budget.map(ThinkingConfig::enabled);
+        self.template.output_config = None;
+        self.effort = None;
+    }
+
+    /// Sets adaptive thinking with an optional effort level.
+    pub fn set_thinking_adaptive(&mut self, effort: Option<Effort>) {
+        self.template.thinking = Some(ThinkingConfig::Adaptive);
+        self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
+        self.effort = effort;
+    }
+
+    /// Sets the effort level for adaptive thinking.
+    pub fn set_effort(&mut self, effort: Option<Effort>) {
+        self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
+        self.effort = effort;
     }
 
     /// Sets the session token budget.
@@ -313,6 +419,10 @@ impl TryFrom<ChatArgs> for ChatConfig {
 
     fn try_from(args: ChatArgs) -> Result<Self, Self::Error> {
         let use_color = !args.no_color;
+        let effort = match args.effort.as_deref() {
+            Some(s) => Some(parse_effort(s)?),
+            None => None,
+        };
         let template = default_template().merge(MessageCreateTemplate::try_from(args)?);
 
         Ok(ChatConfig {
@@ -321,6 +431,7 @@ impl TryFrom<ChatArgs> for ChatConfig {
             session_budget: None,
             transcript_path: None,
             caching_enabled: true,
+            effort,
         })
     }
 }
@@ -348,6 +459,9 @@ mod tests {
         assert!(config.template.top_k.is_none());
         assert!(config.stop_sequences().is_empty());
         assert!(config.thinking_budget().is_none());
+        assert!(config.thinking_config().is_none());
+        assert!(config.effort().is_none());
+        assert!(config.output_config().is_none());
         assert!(config.session_budget.is_none());
         assert!(config.transcript_path.is_none());
         assert!(config.caching_enabled);
@@ -373,6 +487,7 @@ mod tests {
             top_p: Some("0.9".to_string()),
             top_k: Some(40),
             thinking: Some(2048),
+            effort: None,
             no_color: true,
         };
         let config = ChatConfig::try_from(args).unwrap();
@@ -437,6 +552,13 @@ mod tests {
         assert_eq!(config.stop_sequences(), vec!["END".to_string()]);
         assert_eq!(config.thinking_budget(), Some(2048));
         assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: 2048
+            })
+        );
+        assert_eq!(config.effort(), None);
+        assert_eq!(
             config
                 .session_budget
                 .as_ref()
@@ -448,5 +570,50 @@ mod tests {
             Some(PathBuf::from("transcript.json"))
         );
         assert!(!config.caching_enabled);
+    }
+
+    #[test]
+    fn config_adaptive_thinking() {
+        let config = ChatConfig::new().with_thinking_adaptive(Some(Effort::High));
+
+        assert_eq!(config.thinking_config(), Some(ThinkingConfig::Adaptive));
+        assert_eq!(config.effort(), Some(Effort::High));
+        assert_eq!(config.thinking_budget(), None);
+        assert!(config.output_config().is_some());
+        assert_eq!(
+            config.output_config().unwrap().effort,
+            Some(Effort::High)
+        );
+    }
+
+    #[test]
+    fn set_thinking_budget_clears_effort() {
+        let mut config = ChatConfig::new().with_thinking_adaptive(Some(Effort::Medium));
+        assert_eq!(config.effort(), Some(Effort::Medium));
+
+        config.set_thinking_budget(Some(4096));
+        assert_eq!(config.thinking_budget(), Some(4096));
+        assert_eq!(config.effort(), None);
+    }
+
+    #[test]
+    fn set_thinking_adaptive_mutator() {
+        let mut config = ChatConfig::new().with_thinking_budget(Some(4096));
+        assert_eq!(config.thinking_budget(), Some(4096));
+
+        config.set_thinking_adaptive(Some(Effort::Low));
+        assert_eq!(config.thinking_config(), Some(ThinkingConfig::Adaptive));
+        assert_eq!(config.effort(), Some(Effort::Low));
+        assert_eq!(config.thinking_budget(), None);
+    }
+
+    #[test]
+    fn with_thinking_budget_clears_effort() {
+        let config = ChatConfig::new()
+            .with_thinking_adaptive(Some(Effort::High))
+            .with_thinking_budget(Some(2048));
+
+        assert_eq!(config.thinking_budget(), Some(2048));
+        assert_eq!(config.effort(), None);
     }
 }

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -22,5 +22,5 @@ mod session;
 
 pub use crate::render::{PlainTextRenderer, Renderer, StreamContext};
 pub use commands::{ChatCommand, help_text, parse_command};
-pub use config::{ChatArgs, ChatArgsError, ChatConfig};
+pub use config::{ChatArgs, ChatArgsError, ChatConfig, ThinkingMode};
 pub use session::{ChatAgent, ChatSession, ConfigAgent, SessionStats};

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -14,8 +14,8 @@ use serde_json::{from_reader, to_writer_pretty};
 use crate::Error;
 use crate::chat::config::ChatConfig;
 use crate::error::Result;
-use crate::types::{MessageCreateTemplate, MessageParam, Model, SystemPrompt, Usage};
-use crate::{Agent, Anthropic, Budget, Renderer, ThinkingConfig, TurnOutcome};
+use crate::types::{Effort, MessageCreateTemplate, MessageParam, Model, SystemPrompt, Usage};
+use crate::{Agent, Anthropic, Budget, OutputConfig, Renderer, ThinkingConfig, TurnOutcome};
 
 const BUDGET_BUFFER_MICRO_CENTS: u64 = 1;
 
@@ -82,6 +82,10 @@ impl Agent for ConfigAgent {
     async fn top_p(&self) -> Option<f32> {
         self.config.template.top_p
     }
+
+    async fn output_config(&self) -> Option<OutputConfig> {
+        self.config.output_config()
+    }
 }
 
 impl ChatAgent for ConfigAgent {
@@ -129,6 +133,12 @@ pub struct SessionStats {
     pub stop_sequences: Vec<String>,
     /// Extended thinking budget (None = disabled, Some(n) = enabled with n tokens).
     pub thinking_budget: Option<u32>,
+    /// The full thinking configuration (Adaptive, Enabled, Disabled, or None).
+    pub thinking_config: Option<ThinkingConfig>,
+    /// Whether adaptive thinking is enabled.
+    pub thinking_adaptive: bool,
+    /// The configured effort level for adaptive thinking, if any.
+    pub effort: Option<Effort>,
     /// The session token budget limit, if set.
     pub session_budget_tokens: Option<u64>,
     /// Total tokens spent against the budget.
@@ -328,6 +338,9 @@ impl<A: ChatAgent> ChatSession<A> {
             top_k: config.template.top_k,
             stop_sequences: config.template.stop_sequences.clone().unwrap_or_default(),
             thinking_budget: config.thinking_budget(),
+            thinking_config: config.thinking_config(),
+            thinking_adaptive: matches!(config.thinking_mode(), crate::chat::config::ThinkingMode::Adaptive(_)),
+            effort: config.effort(),
             session_budget_tokens,
             budget_spent_tokens,
             transcript_path: config.transcript_path.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use prompt::{
 pub use pty::{BashPtyConfig, BashPtyResult, BashPtySession};
 pub use render::{AgentStreamContext, OperatorLine, PlainTextRenderer, Renderer, StreamContext};
 pub use sse::{SseEvent, parse_message_stream_event, process_message_stream_sse, process_sse};
+pub use chat::ThinkingMode;
 pub use types::*;
 
 /// Pushes a message to the messages vector, or merges it with the last message if they have the same role.

--- a/src/types/message_create_template.rs
+++ b/src/types/message_create_template.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    MessageCreateParams, MessageParam, Metadata, Model, SystemPrompt, ThinkingConfig, ToolChoice,
-    ToolUnionParam,
+    MessageCreateParams, MessageParam, Metadata, Model, OutputConfig, SystemPrompt,
+    ThinkingConfig, ToolChoice, ToolUnionParam,
 };
 
 /// A template for creating message parameters.
@@ -55,6 +55,10 @@ pub struct MessageCreateTemplate {
     /// Amount of randomness injected into the response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
+
+    /// Output configuration (effort level, structured output format).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
 
     /// Configuration for enabling Claude's extended thinking.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -150,6 +154,12 @@ impl MessageCreateTemplate {
         Ok(self)
     }
 
+    /// Set the output configuration.
+    pub fn with_output_config(mut self, output_config: OutputConfig) -> Self {
+        self.output_config = Some(output_config);
+        self
+    }
+
     /// Set the thinking configuration field.
     pub fn with_thinking(mut self, thinking: ThinkingConfig) -> Self {
         self.thinking = Some(thinking);
@@ -210,6 +220,9 @@ impl MessageCreateTemplate {
         if other.temperature.is_some() {
             self.temperature = other.temperature;
         }
+        if other.output_config.is_some() {
+            self.output_config = other.output_config;
+        }
         if other.thinking.is_some() {
             self.thinking = other.thinking;
         }
@@ -258,6 +271,9 @@ impl MessageCreateTemplate {
         if let Some(temperature) = self.temperature {
             params.temperature = Some(temperature);
         }
+        if let Some(output_config) = self.output_config {
+            params.output_config = Some(output_config);
+        }
         if let Some(thinking) = self.thinking {
             params.thinking = Some(thinking);
         }
@@ -296,6 +312,7 @@ mod tests {
         assert!(template.stop_sequences.is_none());
         assert!(template.system.is_none());
         assert!(template.temperature.is_none());
+        assert!(template.output_config.is_none());
         assert!(template.thinking.is_none());
         assert!(template.tool_choice.is_none());
         assert!(template.tools.is_none());


### PR DESCRIPTION
Add support for adaptive thinking mode and configurable effort levels
(low, medium, high) as an alternative to fixed thinking token budgets.

Agent trait:
- Add output_config() method to pass effort levels via OutputConfig
- Wire output_config into MessageCreateParams construction

Chat commands:
- /thinking adaptive: enable adaptive thinking mode
- /effort low|medium|high|clear: set effort level for adaptive thinking
- Update /thinking help text to document adaptive option

ChatConfig:
- Add effort field and builder/mutator methods
- with_thinking_budget and set_thinking_budget clear effort to avoid
  conflicting modes
- Add thinking_config() accessor for full ThinkingConfig discrimination
- Add output_config() to build OutputConfig from effort level

Session:
- Add thinking_config and effort to SessionStats
- Wire ConfigAgent to delegate output_config from ChatConfig
- Update stats and config display to describe adaptive thinking

Includes tests for command parsing, config builders, mutators, and the
interaction between budget-based and adaptive thinking modes.

Add OutputConfig support to MessageCreateTemplate so that adaptive
thinking effort levels are properly serialized into API requests.
Changes include:

- Add ThinkingMode enum to express resolved thinking state (Disabled,
  Adaptive, or Budgeted)
- Add --effort CLI flag to ChatArgs for setting adaptive thinking effort
- Add parse_effort helper for low/medium/high string parsing
- Thread output_config through MessageCreateTemplate merge and build
- Keep output_config in sync across all thinking/effort setters and
  mutators on ChatConfig
- Add thinking_mode() accessor to ChatConfig for resolved mode queries
- Expose thinking_adaptive flag in SessionStats

Co-authored-by: AI
