### PR TITLE
fix: switch HTTP client from overall timeout to inactivity-based timeouts

### DIFF
--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -294,10 +294,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 Effort::Medium => "medium",
                                 Effort::High => "high",
                             };
-                            terminal.print_info(
-                                &context,
-                                &format!("Effort level set to {label}."),
-                            );
+                            terminal.print_info(&context, &format!("Effort level set to {label}."));
                         }
                         ChatCommand::ClearEffort => {
                             session.config_mut().set_effort(None);

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -278,9 +278,9 @@ fn parse_effort_command(argument: Option<&str>) -> ChatCommand {
         "medium" | "med" => ChatCommand::Effort(crate::types::Effort::Medium),
         "high" => ChatCommand::Effort(crate::types::Effort::High),
         "clear" | "off" | "none" => ChatCommand::ClearEffort,
-        _ => ChatCommand::Invalid(
-            "/effort expects 'low', 'medium', 'high', or 'clear'".to_string(),
-        ),
+        _ => {
+            ChatCommand::Invalid("/effort expects 'low', 'medium', 'high', or 'clear'".to_string())
+        }
     }
 }
 
@@ -448,10 +448,7 @@ mod tests {
             parse_command("/effort clear"),
             Some(ChatCommand::ClearEffort)
         );
-        assert_eq!(
-            parse_command("/effort off"),
-            Some(ChatCommand::ClearEffort)
-        );
+        assert_eq!(parse_command("/effort off"), Some(ChatCommand::ClearEffort));
         assert!(matches!(
             parse_command("/effort"),
             Some(ChatCommand::Invalid(msg)) if msg.contains("expects")

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -62,7 +62,11 @@ pub struct ChatArgs {
     pub thinking: Option<u32>,
 
     /// Effort level for adaptive thinking (low, medium, high).
-    #[arrrg(optional, "Effort level for adaptive thinking (low, medium, high)", "LEVEL")]
+    #[arrrg(
+        optional,
+        "Effort level for adaptive thinking (low, medium, high)",
+        "LEVEL"
+    )]
     pub effort: Option<String>,
 
     /// Disable ANSI colors and styles.
@@ -580,10 +584,7 @@ mod tests {
         assert_eq!(config.effort(), Some(Effort::High));
         assert_eq!(config.thinking_budget(), None);
         assert!(config.output_config().is_some());
-        assert_eq!(
-            config.output_config().unwrap().effort,
-            Some(Effort::High)
-        );
+        assert_eq!(config.output_config().unwrap().effort, Some(Effort::High));
     }
 
     #[test]

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -339,7 +339,10 @@ impl<A: ChatAgent> ChatSession<A> {
             stop_sequences: config.template.stop_sequences.clone().unwrap_or_default(),
             thinking_budget: config.thinking_budget(),
             thinking_config: config.thinking_config(),
-            thinking_adaptive: matches!(config.thinking_mode(), crate::chat::config::ThinkingMode::Adaptive(_)),
+            thinking_adaptive: matches!(
+                config.thinking_mode(),
+                crate::chat::config::ThinkingMode::Adaptive(_)
+            ),
             effort: config.effort(),
             session_budget_tokens,
             budget_spent_tokens,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::error::Error as StdError;
 use std::fs;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -78,8 +79,22 @@ impl Stream for LoggingStream<'_> {
 
 const DEFAULT_API_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
+/// Default connect/read inactivity timeout shared by all requests.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
+
+fn format_reqwest_error(err: &reqwest::Error) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source = StdError::source(err);
+    while let Some(inner) = source {
+        let detail = inner.to_string();
+        if !parts.iter().any(|part| part == &detail) {
+            parts.push(detail);
+        }
+        source = inner.source();
+    }
+    parts.join(": ")
+}
 
 /// Client for the Anthropic API with performance optimizations.
 #[derive(Debug, Clone)]
@@ -96,6 +111,22 @@ pub struct Anthropic {
 }
 
 impl Anthropic {
+    fn build_http_client(timeout: Duration) -> Result<ReqwestClient> {
+        ReqwestClient::builder()
+            .connect_timeout(timeout)
+            .read_timeout(timeout)
+            .pool_max_idle_per_host(10) // Connection pooling optimization
+            .pool_idle_timeout(Duration::from_secs(90))
+            .tcp_keepalive(Duration::from_secs(60))
+            .build()
+            .map_err(|e| {
+                Error::http_client(
+                    format!("Failed to build HTTP client: {e}"),
+                    Some(Box::new(e)),
+                )
+            })
+    }
+
     /// Resolve an API key value, handling file:// URLs
     fn resolve_api_key(key_value: &str) -> Result<String> {
         if let Some(stripped) = key_value.strip_prefix("file://") {
@@ -147,18 +178,7 @@ impl Anthropic {
         };
 
         let timeout = DEFAULT_TIMEOUT;
-        let client = ReqwestClient::builder()
-            .timeout(timeout)
-            .pool_max_idle_per_host(10) // Connection pooling optimization
-            .pool_idle_timeout(Duration::from_secs(90))
-            .tcp_keepalive(Duration::from_secs(60))
-            .build()
-            .map_err(|e| {
-                Error::http_client(
-                    format!("Failed to build HTTP client: {e}"),
-                    Some(Box::new(e)),
-                )
-            })?;
+        let client = Self::build_http_client(timeout)?;
 
         // Pre-build headers for performance
         let cached_headers = Arc::new(Self::build_default_headers(&api_key)?);
@@ -210,25 +230,18 @@ impl Anthropic {
 
     /// Set a custom timeout for this client.
     ///
-    /// This method allows you to specify a different timeout for API requests.
+    /// This method allows you to specify a different connect/read inactivity
+    /// timeout for API requests.
     pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
         self.timeout = timeout;
 
-        // Recreate the client with the new timeout and performance optimizations
-        let client = ReqwestClient::builder()
-            .timeout(timeout)
-            .pool_max_idle_per_host(10)
-            .pool_idle_timeout(Duration::from_secs(90))
-            .tcp_keepalive(Duration::from_secs(60))
-            .build()
-            .map_err(|e| {
-                Error::http_client(
-                    "Failed to build HTTP client with new timeout",
-                    Some(Box::new(e)),
-                )
-            })?;
-
-        self.client = client;
+        self.client = Self::build_http_client(timeout).map_err(|e| match e {
+            Error::HttpClient { source, .. } => Error::http_client(
+                "Failed to build HTTP client with new timeout",
+                source.map(|src| Box::new(src) as Box<dyn std::error::Error + Send + Sync>),
+            ),
+            other => other,
+        })?;
         Ok(self)
     }
 
@@ -440,15 +453,36 @@ impl Anthropic {
 
     /// Convert reqwest errors to appropriate Error types
     fn map_request_error(&self, e: reqwest::Error) -> Error {
+        let details = format_reqwest_error(&e);
         if e.is_timeout() {
             Error::timeout(
-                format!("Request timed out: {e}"),
+                format!("Request timed out: {details}"),
                 Some(self.timeout.as_secs_f64()),
             )
         } else if e.is_connect() {
-            Error::connection(format!("Connection error: {e}"), Some(Box::new(e)))
+            Error::connection(format!("Connection error: {details}"), Some(Box::new(e)))
         } else {
-            Error::http_client(format!("Request failed: {e}"), Some(Box::new(e)))
+            Error::http_client(format!("Request failed: {details}"), Some(Box::new(e)))
+        }
+    }
+
+    fn map_response_body_error(&self, e: reqwest::Error) -> Error {
+        let details = format_reqwest_error(&e);
+        if e.is_timeout() {
+            Error::timeout(
+                format!("Response body timed out: {details}"),
+                Some(self.timeout.as_secs_f64()),
+            )
+        } else if e.is_connect() {
+            Error::connection(
+                format!("Response body connection error: {details}"),
+                Some(Box::new(e)),
+            )
+        } else {
+            Error::http_client(
+                format!("Failed to read response body: {details}"),
+                Some(Box::new(e)),
+            )
         }
     }
 
@@ -474,7 +508,12 @@ impl Anthropic {
             return Err(Self::process_error_response(response).await);
         }
 
-        response.json::<T>().await.map_err(|e| {
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| self.map_response_body_error(e))?;
+
+        serde_json::from_slice::<T>(&body).map_err(|e| {
             Error::serialization(format!("Failed to parse response: {e}"), Some(Box::new(e)))
         })
     }
@@ -502,7 +541,12 @@ impl Anthropic {
             return Err(Self::process_error_response(response).await);
         }
 
-        response.json::<T>().await.map_err(|e| {
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| self.map_response_body_error(e))?;
+
+        serde_json::from_slice::<T>(&body).map_err(|e| {
             Error::serialization(format!("Failed to parse response: {e}"), Some(Box::new(e)))
         })
     }
@@ -750,8 +794,70 @@ impl Anthropic {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{KnownModel, MessageParam, Model};
+    use futures::StreamExt;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn request_headers_end(buffer: &[u8]) -> Option<usize> {
+        buffer.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(
+                read > 0,
+                "client closed the connection before sending headers"
+            );
+            buffer.extend_from_slice(&chunk[..read]);
+            if request_headers_end(&buffer).is_some() {
+                break;
+            }
+        }
+
+        let headers_end = request_headers_end(&buffer).unwrap();
+        let headers = String::from_utf8_lossy(&buffer[..headers_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let mut parts = line.splitn(2, ':');
+                let name = parts.next()?.trim();
+                let value = parts.next()?.trim();
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+
+        while buffer.len() - (headers_end + 4) < content_length {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(
+                read > 0,
+                "client closed the connection before sending the full body"
+            );
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+    }
+
+    async fn start_test_server<F, Fut>(handler: F) -> String
+    where
+        F: FnOnce(tokio::net::TcpStream) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            socket.set_nodelay(true).unwrap();
+            handler(socket).await;
+        });
+        format!("http://{}", address)
+    }
 
     #[tokio::test]
     async fn retry_logic_with_backoff() {
@@ -1122,5 +1228,127 @@ mod tests {
 
         // Verify all operations executed
         assert_eq!(attempt_counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn streaming_timeout_is_inactivity_based() {
+        let base_url = start_test_server(|mut socket| async move {
+            read_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+Content-Type: text/event-stream\r\n\
+Cache-Control: no-cache\r\n\
+Connection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+
+            for chunk in [
+                b"event: ping\n".as_slice(),
+                b"data: {}\n".as_slice(),
+                b"\n".as_slice(),
+            ] {
+                socket.write_all(chunk).await.unwrap();
+                socket.flush().await.unwrap();
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url)
+            .with_timeout(Duration::from_millis(75))
+            .unwrap();
+        let params = MessageCreateParams::new_streaming(
+            16,
+            vec![MessageParam::user("ping")],
+            Model::Known(KnownModel::ClaudeHaiku45),
+        );
+
+        let mut stream = std::pin::pin!(client.stream(&params).await.unwrap());
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first, MessageStreamEvent::Ping);
+    }
+
+    #[tokio::test]
+    async fn streaming_stall_reports_timeout_error() {
+        let base_url = start_test_server(|mut socket| async move {
+            read_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+Content-Type: text/event-stream\r\n\
+Cache-Control: no-cache\r\n\
+Connection: close\r\n\r\n\
+event: ping\n",
+                )
+                .await
+                .unwrap();
+            socket.flush().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(120)).await;
+            socket.write_all(b"data: {}\n\n").await.unwrap();
+            socket.flush().await.unwrap();
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url)
+            .with_timeout(Duration::from_millis(50))
+            .unwrap();
+        let params = MessageCreateParams::new_streaming(
+            16,
+            vec![MessageParam::user("ping")],
+            Model::Known(KnownModel::ClaudeHaiku45),
+        );
+
+        let mut stream = std::pin::pin!(client.stream(&params).await.unwrap());
+        let err = stream.next().await.unwrap().unwrap_err();
+        assert!(matches!(err, Error::Timeout { .. }));
+        assert!(err.to_string().contains("operation timed out"));
+    }
+
+    #[tokio::test]
+    async fn non_streaming_body_stall_reports_timeout_error() {
+        let base_url = start_test_server(|mut socket| async move {
+            read_http_request(&mut socket).await;
+            let body_prefix = b"{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-haiku-4-5-20251001\",\"content\":[{\"type\":\"text\",\"text\":\"hel";
+            let body_suffix = b"lo\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}";
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\n\
+Content-Type: application/json\r\n\
+Content-Length: {}\r\n\
+Connection: close\r\n\r\n",
+                body_prefix.len() + body_suffix.len()
+            );
+            socket
+                .write_all(headers.as_bytes())
+                .await
+                .unwrap();
+            socket.write_all(body_prefix).await.unwrap();
+            socket.flush().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(120)).await;
+            socket.write_all(body_suffix).await.unwrap();
+            socket.flush().await.unwrap();
+            socket.shutdown().await.unwrap();
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url)
+            .with_timeout(Duration::from_millis(50))
+            .unwrap()
+            .with_max_retries(0);
+        let params = MessageCreateParams::new(
+            16,
+            vec![MessageParam::user("ping")],
+            Model::Known(KnownModel::ClaudeHaiku45),
+        );
+
+        let err = client.send(params).await.unwrap_err();
+        assert!(matches!(err, Error::Timeout { .. }), "{err:?}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use agent::{
     Agent, Budget, FileSystem, IntermediateToolResult, Mount, MountHierarchy, Permissions,
     TokenKind, Tool, ToolCallback, ToolResult, ToolSearchFileSystem, TurnOutcome, TurnStep,
 };
+pub use chat::ThinkingMode;
 pub use client::{Anthropic, LoggingStream};
 pub use client_logger::ClientLogger;
 pub use error::{Error, Result};
@@ -40,7 +41,6 @@ pub use prompt::{
 pub use pty::{BashPtyConfig, BashPtyResult, BashPtySession};
 pub use render::{AgentStreamContext, OperatorLine, PlainTextRenderer, Renderer, StreamContext};
 pub use sse::{SseEvent, parse_message_stream_event, process_message_stream_sse, process_sse};
-pub use chat::ThinkingMode;
 pub use types::*;
 
 /// Pushes a message to the messages vector, or merges it with the last message if they have the same role.

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -5,6 +5,7 @@
 
 use bytes::Bytes;
 use futures::stream::{self, Stream, StreamExt};
+use std::error::Error as StdError;
 use std::time::{Duration, Instant};
 
 use crate::observability::{
@@ -63,10 +64,7 @@ where
     S: Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Unpin + 'static,
 {
     // Convert reqwest errors to our error type
-    let stream = byte_stream.map(|result| {
-        result
-            .map_err(|e| Error::streaming(format!("Error in HTTP stream: {e}"), Some(Box::new(e))))
-    });
+    let stream = byte_stream.map(|result| result.map_err(map_http_stream_error));
 
     // Initialize state with production hardening
     let state = SseState {
@@ -198,6 +196,36 @@ where
             }
         }
     })
+}
+
+fn map_http_stream_error(err: reqwest::Error) -> Error {
+    let details = format_reqwest_error(&err);
+    if err.is_timeout() {
+        Error::timeout(format!("HTTP stream timed out: {details}"), None)
+    } else if err.is_connect() {
+        Error::connection(
+            format!("HTTP stream connection error: {details}"),
+            Some(Box::new(err)),
+        )
+    } else {
+        Error::streaming(
+            format!("Error in HTTP stream: {details}"),
+            Some(Box::new(err)),
+        )
+    }
+}
+
+fn format_reqwest_error(err: &reqwest::Error) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source = StdError::source(err);
+    while let Some(inner) = source {
+        let detail = inner.to_string();
+        if !parts.iter().any(|part| part == &detail) {
+            parts.push(detail);
+        }
+        source = inner.source();
+    }
+    parts.join(": ")
 }
 
 /// Decode a raw [`SseEvent`] into a Claudius [`MessageStreamEvent`].

--- a/src/types/message_create_template.rs
+++ b/src/types/message_create_template.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    MessageCreateParams, MessageParam, Metadata, Model, OutputConfig, SystemPrompt,
-    ThinkingConfig, ToolChoice, ToolUnionParam,
+    MessageCreateParams, MessageParam, Metadata, Model, OutputConfig, SystemPrompt, ThinkingConfig,
+    ToolChoice, ToolUnionParam,
 };
 
 /// A template for creating message parameters.


### PR DESCRIPTION
Replace the single reqwest::Client::timeout (which caps the entire
request lifecycle) with connect_timeout + read_timeout so that
long-running streaming responses are not killed as long as data
keeps arriving.  This fixes spurious timeout errors on large
streaming completions while still detecting stalled connections.

Key changes:
- Extract build_http_client() to centralise client construction
- Use connect_timeout and read_timeout instead of timeout
- Add format_reqwest_error() to unwrap nested reqwest error sources
  for clearer diagnostics (in both client.rs and sse.rs)
- Add map_response_body_error() to distinguish body-read failures
  from request-send failures
- Switch non-streaming paths from response.json() to
  response.bytes() + serde_json::from_slice() so body-read
  timeouts surface as Timeout errors rather than Serialization
- Classify SSE stream errors into Time- Classify SSE stream errors into Time- Clasmap_http_stream_error()
- Add TCP-level integration tests for inactivity timeout behaviour
  in both streaming and non-streaming paths

Includes incidental rustfmt reformatting and pub-use reordering.

Co-authored-by: AI
