### PR TITLE
feat: unify session spend with turn budget allocation

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1075,6 +1075,60 @@ impl Budget {
     /// ```
     pub fn allocate(&self, max_tokens: u32) -> Option<BudgetAllocation<'_>> {
         let max_cost = self.calculate_output_cost_for_tokens(max_tokens);
+        self.allocate_micro_cents(max_cost)
+    }
+
+    /// Attempts to allocate as many output tokens as the budget can currently fund.
+    ///
+    /// Unlike [`allocate`], this method does not fail just because the full
+    /// `max_tokens` amount is unavailable. It reserves the smaller of
+    /// `max_tokens` and the remaining output-token capacity. This is useful when
+    /// a request should be capped by remaining spend instead of rejected outright.
+    ///
+    /// Returns `None` when no output token can be funded. A zero-token request
+    /// preserves [`allocate`]'s behavior and returns an empty allocation.
+    ///
+    /// [`allocate`]: Budget::allocate
+    pub fn allocate_available(&self, max_tokens: u32) -> Option<BudgetAllocation<'_>> {
+        if max_tokens == 0 {
+            return self.allocate(0);
+        }
+
+        let rate = self.output_token_rate_micro_cents;
+        if rate == 0 {
+            return self.allocate(max_tokens);
+        }
+
+        let max_cost = self.calculate_output_cost_for_tokens(max_tokens);
+        loop {
+            let witness = self.remaining_micro_cents.load(Ordering::Relaxed);
+            let cost = std::cmp::min(witness, max_cost);
+            let funded_tokens = cost / rate;
+            if funded_tokens == 0 {
+                return None;
+            }
+            let capped_cost = funded_tokens.saturating_mul(rate);
+            if self
+                .remaining_micro_cents
+                .compare_exchange(
+                    witness,
+                    witness.saturating_sub(capped_cost),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                let remaining_micro_cents = Arc::clone(&self.remaining_micro_cents);
+                return Some(BudgetAllocation {
+                    remaining_micro_cents,
+                    allocated_micro_cents: capped_cost,
+                    budget: self,
+                });
+            }
+        }
+    }
+
+    fn allocate_micro_cents(&self, max_cost: u64) -> Option<BudgetAllocation<'_>> {
         loop {
             let witness = self.remaining_micro_cents.load(Ordering::Relaxed);
             if witness >= max_cost
@@ -1139,6 +1193,19 @@ impl Budget {
     /// represents a consistent point-in-time snapshot of the budget state.
     pub fn remaining_micro_cents(&self) -> u64 {
         self.remaining_micro_cents.load(Ordering::Relaxed)
+    }
+
+    /// Returns how many output tokens the current remaining budget can fund.
+    pub fn remaining_output_tokens(&self) -> u32 {
+        if self.output_token_rate_micro_cents == 0 {
+            return u32::MAX;
+        }
+        std::cmp::min(
+            self.remaining_micro_cents()
+                .checked_div(self.output_token_rate_micro_cents)
+                .unwrap_or(0),
+            u32::MAX as u64,
+        ) as u32
     }
 
     /// Returns the total micro-cents allocated to this budget.
@@ -1345,32 +1412,40 @@ impl<'a> BudgetAllocation<'a> {
     ///
     /// Output token costs are charged to this allocation, which represents the
     /// agent's generation budget for the current turn. Input token costs (input,
-    /// cache creation, cache read) are charged directly to the main budget because
-    /// they grow with conversation history and are not under the agent's control.
+    /// cache creation, cache read) are charged directly to the main budget first
+    /// because they grow with conversation history and are not under the agent's
+    /// control. If the main budget cannot cover all input costs, the deficit is
+    /// charged to this allocation so total budget accounting still saturates at
+    /// zero after the request.
     ///
     /// This prevents input token costs from starving the output budget as
     /// conversations grow longer over multiple tool-use steps.
     ///
     /// # Returns
     ///
-    /// - `true` if the output cost was within the remaining allocation
-    /// - `false` if the output cost exceeds the remaining allocation
+    /// - `true` if the output cost plus any input deficit was within the remaining allocation
+    /// - `false` if that cost exceeds the remaining allocation
     ///
-    /// Input costs are always deducted from the main budget (saturating at zero)
-    /// regardless of the return value, because the API call already happened.
+    /// Costs are deducted regardless of the return value, because the API call
+    /// already happened.
     #[must_use]
     pub fn consume_response(&mut self, usage: &crate::Usage) -> bool {
         let input_cost = self.budget.calculate_input_cost(usage);
         let output_cost = self.budget.calculate_output_cost(usage);
 
         // Charge input costs to main budget (sunk cost from the API call).
-        self.budget.consume_cost_micro_cents_saturating(input_cost);
+        let input_consumed = self.budget.consume_cost_micro_cents_saturating(input_cost);
+        let input_deficit = input_cost.saturating_sub(input_consumed);
 
-        // Charge output costs to allocation.
-        if output_cost <= self.allocated_micro_cents {
-            self.allocated_micro_cents -= output_cost;
+        // Charge output costs to allocation. If the main budget could not cover
+        // all input costs, charge that deficit to the reserved output budget so
+        // total spend still saturates at zero after the request.
+        let allocation_cost = output_cost.saturating_add(input_deficit);
+        if allocation_cost <= self.allocated_micro_cents {
+            self.allocated_micro_cents -= allocation_cost;
             true
         } else {
+            self.allocated_micro_cents = 0;
             false
         }
     }
@@ -1781,7 +1856,7 @@ pub trait Agent: Send + Sync + Sized {
         budget: &Arc<Budget>,
     ) -> Result<TurnOutcome, Error> {
         let turn_start = Instant::now();
-        let Some(mut tokens_rem) = budget.allocate(self.max_tokens().await) else {
+        let Some(mut tokens_rem) = budget.allocate_available(self.max_tokens().await) else {
             AGENT_TURN_DURATION.add(turn_start.elapsed().as_secs_f64());
             let stop_reason = self.handle_max_tokens().await?;
             return Ok(TurnOutcome {
@@ -1831,7 +1906,7 @@ pub trait Agent: Send + Sync + Sized {
     ) -> Result<TurnOutcome, Error> {
         let turn_start = Instant::now();
         renderer.start_agent(&context);
-        let Some(mut tokens_rem) = budget.allocate(self.max_tokens().await) else {
+        let Some(mut tokens_rem) = budget.allocate_available(self.max_tokens().await) else {
             AGENT_TURN_DURATION.add(turn_start.elapsed().as_secs_f64());
             let stop_reason = self.handle_max_tokens().await?;
             renderer.finish_agent(&context, Some(&stop_reason));
@@ -2871,23 +2946,25 @@ async fn step_default_turn_impl<A: Agent>(
             }
         };
 
-        if let Err(err) = agent.hook_message(&resp).await {
-            return ControlFlow::Break(Err(err));
-        }
-
         let assistant_message = MessageParam {
             role: MessageRole::Assistant,
             content: MessageParamContent::Array(resp.content.clone()),
         };
         usage_total = usage_total + resp.usage;
-        if !tokens_rem.consume_response(&resp.usage) {
+        request_count = request_count.saturating_add(1);
+        let response_within_budget = tokens_rem.consume_response(&resp.usage);
+
+        if let Err(err) = agent.hook_message(&resp).await {
+            return ControlFlow::Break(Err(err));
+        }
+
+        if !response_within_budget {
             return ControlFlow::Break(Ok(TurnOutcome {
                 stop_reason: StopReason::MaxTokens,
                 usage: usage_total,
                 request_count,
             }));
         }
-        request_count = request_count.saturating_add(1);
         push_or_merge_message(messages, assistant_message);
 
         let tool_results = match resp.stop_reason {
@@ -3185,6 +3262,23 @@ mod tests {
         let allocation = budget.allocate(100);
         assert!(allocation.is_none());
         assert_eq!(budget.remaining_micro_cents(), 500);
+    }
+
+    #[test]
+    fn budget_allocate_available_caps_to_remaining_output_tokens() {
+        let budget = Budget::new_flat_rate(255, 10);
+        let allocation = budget.allocate_available(100).unwrap();
+
+        assert_eq!(allocation.remaining_tokens(), 25);
+        assert_eq!(budget.remaining_micro_cents(), 5);
+    }
+
+    #[test]
+    fn budget_allocate_available_fails_when_no_output_token_fits() {
+        let budget = Budget::new_flat_rate(9, 10);
+
+        assert!(budget.allocate_available(100).is_none());
+        assert_eq!(budget.remaining_micro_cents(), 9);
     }
 
     #[test]
@@ -4911,6 +5005,21 @@ mod tests {
     }
 
     #[test]
+    fn consume_response_charges_input_deficit_to_allocation() {
+        let budget = Budget::new_flat_rate(1000, 10);
+        let initial_budget = budget.remaining_micro_cents();
+
+        let mut allocation = budget.allocate_available(100).unwrap();
+        assert_eq!(budget.remaining_micro_cents(), 0);
+
+        let usage = Usage::new(20, 30);
+        assert!(allocation.consume_response(&usage));
+
+        drop(allocation);
+        assert_eq!(budget.remaining_micro_cents(), initial_budget - 500);
+    }
+
+    #[test]
     fn consume_response_input_does_not_starve_output_budget() {
         // This test demonstrates the fix: large input costs don't drain the output budget.
         let budget = Budget::new_with_rates(500_000_000, 300, 1500, 375, 30);
@@ -4974,6 +5083,44 @@ mod tests {
         // Allocated at output rate: 50 * 1500 = 75_000
         assert_eq!(budget.remaining_micro_cents(), 25_000);
         assert_eq!(allocation.remaining_tokens(), 50);
+    }
+
+    struct RequestCapAgent {
+        seen_max_tokens: Arc<std::sync::Mutex<Option<u32>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Agent for RequestCapAgent {
+        async fn max_tokens(&self) -> u32 {
+            100
+        }
+
+        async fn hook_message_create_params(&self, req: &MessageCreateParams) -> Result<(), Error> {
+            *self.seen_max_tokens.lock().unwrap() = Some(req.max_tokens);
+            Err(Error::bad_request(
+                "stop before network",
+                Some("max_tokens".to_string()),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn default_turn_caps_request_max_tokens_to_available_budget() {
+        let seen_max_tokens = Arc::new(std::sync::Mutex::new(None));
+        let mut agent = RequestCapAgent {
+            seen_max_tokens: Arc::clone(&seen_max_tokens),
+        };
+        let client = Anthropic::new(None).unwrap();
+        let budget = Arc::new(Budget::new_flat_rate(255, 10));
+        let mut messages = vec![MessageParam::user("hello")];
+
+        let err = agent
+            .take_turn(&client, &mut messages, &budget)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::BadRequest { .. }));
+        assert_eq!(*seen_max_tokens.lock().unwrap(), Some(25));
     }
 
     // Budget State Management Tests

--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -301,14 +301,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             terminal.print_info(&context, "Effort level cleared.");
                         }
                         ChatCommand::Spend(dollars) => {
-                            session.config_mut().set_session_spend(Some(dollars));
+                            session.set_session_spend(Some(dollars));
                             terminal.print_info(
                                 &context,
                                 &format!("Session spend limit set to ${dollars:.2}."),
                             );
                         }
                         ChatCommand::ClearSpend => {
-                            session.config_mut().session_spend = None;
+                            session.set_session_spend(None);
                             terminal.print_info(&context, "Session spend limit cleared.");
                         }
                         ChatCommand::Caching(enabled) => {

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -464,18 +464,9 @@ mod tests {
 
     #[test]
     fn parse_spend() {
-        assert_eq!(
-            parse_command("/spend 5.0"),
-            Some(ChatCommand::Spend(5.0))
-        );
-        assert_eq!(
-            parse_command("/spend 0.50"),
-            Some(ChatCommand::Spend(0.50))
-        );
-        assert_eq!(
-            parse_command("/spend clear"),
-            Some(ChatCommand::ClearSpend)
-        );
+        assert_eq!(parse_command("/spend 5.0"), Some(ChatCommand::Spend(5.0)));
+        assert_eq!(parse_command("/spend 0.50"), Some(ChatCommand::Spend(0.50)));
+        assert_eq!(parse_command("/spend clear"), Some(ChatCommand::ClearSpend));
         assert!(matches!(
             parse_command("/spend -1.0"),
             Some(ChatCommand::Invalid(_))

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -273,6 +273,15 @@ impl ChatConfig {
         self
     }
 
+    /// Sets the session spend budget object directly.
+    ///
+    /// Cloning a [`Budget`] preserves its remaining-spend state, so this can be
+    /// used to carry spend accounting across rebuilt chat sessions.
+    pub fn with_session_spend_budget(mut self, budget: Option<Budget>) -> Self {
+        self.session_spend = budget;
+        self
+    }
+
     /// Sets the transcript auto-save path.
     pub fn with_transcript_path(mut self, path: Option<PathBuf>) -> Self {
         self.transcript_path = path;
@@ -405,6 +414,14 @@ impl ChatConfig {
     /// Sets the session spend limit in dollars, using the configured model's token rates.
     pub fn set_session_spend(&mut self, dollars: Option<f64>) {
         self.session_spend = dollars.map(|d| self.dollar_budget(d));
+    }
+
+    /// Sets the session spend budget object directly.
+    ///
+    /// Cloning a [`Budget`] preserves its remaining-spend state, so this can be
+    /// used to carry spend accounting across rebuilt chat sessions.
+    pub fn set_session_spend_budget(&mut self, budget: Option<Budget>) {
+        self.session_spend = budget;
     }
 
     fn dollar_budget(&self, dollars: f64) -> Budget {

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -17,8 +17,6 @@ use crate::error::Result;
 use crate::types::{Effort, MessageCreateTemplate, MessageParam, Model, SystemPrompt, Usage};
 use crate::{Agent, Anthropic, Budget, OutputConfig, Renderer, ThinkingConfig, TurnOutcome};
 
-const SPEND_BUFFER_MICRO_CENTS: u64 = 1;
-
 /// Agent behavior expected by the chat session.
 pub trait ChatAgent: Agent {
     /// Returns the active chat configuration.
@@ -110,6 +108,7 @@ pub struct ChatSession<A: ChatAgent> {
     last_turn_usage: Option<Usage>,
     request_count: u64,
     budget: Arc<Budget>,
+    session_spend: Option<Arc<Budget>>,
 }
 
 /// Aggregated stats for a chat session.
@@ -174,6 +173,7 @@ impl<A: ChatAgent> ChatSession<A> {
     /// Creates a new chat session with a custom agent.
     pub fn with_agent(client: Anthropic, agent: A) -> Self {
         let budget = Arc::new(Budget::new_flat_rate(u64::MAX, 1));
+        let session_spend = agent.config().session_spend.clone().map(Arc::new);
         Self {
             client,
             agent,
@@ -182,6 +182,7 @@ impl<A: ChatAgent> ChatSession<A> {
             last_turn_usage: None,
             request_count: 0,
             budget,
+            session_spend,
         }
     }
 
@@ -198,6 +199,7 @@ impl<A: ChatAgent> ChatSession<A> {
         message: MessageParam,
         renderer: &mut dyn Renderer,
     ) -> Result<()> {
+        self.sync_session_spend_from_config();
         self.ensure_session_spend_for_next_turn(renderer)?;
 
         let previous_len = self.messages.len();
@@ -205,9 +207,10 @@ impl<A: ChatAgent> ChatSession<A> {
         // Add user message to history
         self.messages.push(message);
 
+        let budget = self.turn_budget();
         let outcome = self
             .agent
-            .take_turn_streaming_root(&self.client, &mut self.messages, &self.budget, renderer)
+            .take_turn_streaming_root(&self.client, &mut self.messages, &budget, renderer)
             .await;
 
         match outcome {
@@ -244,12 +247,14 @@ impl<A: ChatAgent> ChatSession<A> {
         messages: &mut Vec<MessageParam>,
         renderer: &mut dyn Renderer,
     ) -> Result<()> {
+        self.sync_session_spend_from_config();
         self.ensure_session_spend_for_next_turn(renderer)?;
 
         let previous_messages = messages.clone();
+        let budget = self.turn_budget();
         let outcome = self
             .agent
-            .take_turn_streaming_root(&self.client, messages, &self.budget, renderer)
+            .take_turn_streaming_root(&self.client, messages, &budget, renderer)
             .await;
 
         match outcome {
@@ -282,6 +287,36 @@ impl<A: ChatAgent> ChatSession<A> {
     /// Returns the chat configuration for mutation.
     pub fn config_mut(&mut self) -> &mut ChatConfig {
         self.agent.config_mut()
+    }
+
+    /// Sets or clears the session spend limit in dollars.
+    ///
+    /// This updates both the visible configuration and the active session
+    /// budget used to cap model requests.
+    pub fn set_session_spend(&mut self, dollars: Option<f64>) {
+        self.agent.config_mut().set_session_spend(dollars);
+        self.session_spend = self.agent.config().session_spend.clone().map(Arc::new);
+    }
+
+    /// Sets or clears the active session spend budget.
+    ///
+    /// Passing a cloned [`Budget`] preserves its remaining-spend state, which is
+    /// useful when rebuilding or switching [`ChatSession`] instances.
+    pub fn set_session_spend_budget(&mut self, budget: Option<Budget>) {
+        self.agent
+            .config_mut()
+            .set_session_spend_budget(budget.clone());
+        self.session_spend = budget.map(Arc::new);
+    }
+
+    /// Returns a clone of the active session spend budget.
+    ///
+    /// The returned [`Budget`] shares the same remaining-spend state as this
+    /// session. Pass it to [`ChatConfig::with_session_spend_budget`] or
+    /// [`ChatSession::set_session_spend_budget`] to preserve spend accounting
+    /// across rebuilt sessions.
+    pub fn session_spend_budget(&self) -> Option<Budget> {
+        self.session_spend.as_deref().cloned()
     }
 
     /// Returns the message template used for requests.
@@ -320,15 +355,15 @@ impl<A: ChatAgent> ChatSession<A> {
     /// Returns the current session statistics snapshot.
     pub fn stats(&self) -> SessionStats {
         let config = self.agent.config();
-        let (session_spend_micro_cents, spend_used_micro_cents) =
-            match config.session_spend.as_ref() {
-                Some(spend) => {
-                    let total = spend.total_micro_cents();
-                    let remaining = spend.remaining_micro_cents();
-                    (Some(total), total.saturating_sub(remaining))
-                }
-                None => (None, 0),
-            };
+        let (session_spend_micro_cents, spend_used_micro_cents) = match self.session_spend.as_ref()
+        {
+            Some(spend) => {
+                let total = spend.total_micro_cents();
+                let remaining = spend.remaining_micro_cents();
+                (Some(total), total.saturating_sub(remaining))
+            }
+            None => (None, 0),
+        };
         SessionStats {
             model: config.model(),
             message_count: self.message_count(),
@@ -375,9 +410,6 @@ impl<A: ChatAgent> ChatSession<A> {
         self.last_turn_usage = Some(outcome.usage);
         self.usage_totals = self.usage_totals + outcome.usage;
         self.request_count = self.request_count.saturating_add(outcome.request_count);
-        if let Some(spend) = self.agent.config().session_spend.as_ref() {
-            spend.consume_usage_saturating(&outcome.usage);
-        }
     }
 
     fn auto_save_transcript(&self) -> Result<()> {
@@ -388,10 +420,26 @@ impl<A: ChatAgent> ChatSession<A> {
         }
     }
 
+    fn turn_budget(&self) -> Arc<Budget> {
+        self.session_spend
+            .as_ref()
+            .map(Arc::clone)
+            .unwrap_or_else(|| Arc::clone(&self.budget))
+    }
+
+    fn sync_session_spend_from_config(&mut self) {
+        if !same_budget_state(
+            self.session_spend.as_deref(),
+            self.agent.config().session_spend.as_ref(),
+        ) {
+            self.session_spend = self.agent.config().session_spend.clone().map(Arc::new);
+        }
+    }
+
     fn ensure_session_spend_for_next_turn(&self, renderer: &mut dyn Renderer) -> Result<()> {
         let context = ();
-        if let Some(spend) = self.agent.config().session_spend.as_ref()
-            && !spend_allows_next_turn(spend, self.last_turn_usage.as_ref())
+        if let Some(spend) = self.session_spend.as_ref()
+            && spend.remaining_output_tokens() == 0
         {
             renderer.print_error(
                 &context,
@@ -425,16 +473,21 @@ fn tokens_to_u64(value: i32) -> u64 {
     value.max(0) as u64
 }
 
-fn spend_allows_next_turn(spend: &Budget, last_turn_usage: Option<&Usage>) -> bool {
-    let remaining = spend.remaining_micro_cents();
-    if remaining == 0 {
-        return false;
+fn same_budget_state(left: Option<&Budget>, right: Option<&Budget>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            left.total_micro_cents() == right.total_micro_cents()
+                && left.remaining_micro_cents() == right.remaining_micro_cents()
+                && left.calculate_cost(&Usage::new(1, 0)) == right.calculate_cost(&Usage::new(1, 0))
+                && left.calculate_cost(&Usage::new(0, 1)) == right.calculate_cost(&Usage::new(0, 1))
+                && left.calculate_cost(&Usage::new(0, 0).with_cache_creation_input_tokens(1))
+                    == right.calculate_cost(&Usage::new(0, 0).with_cache_creation_input_tokens(1))
+                && left.calculate_cost(&Usage::new(0, 0).with_cache_read_input_tokens(1))
+                    == right.calculate_cost(&Usage::new(0, 0).with_cache_read_input_tokens(1))
+        }
+        (None, None) => true,
+        _ => false,
     }
-    let Some(usage) = last_turn_usage else {
-        return true;
-    };
-    let cost = spend.calculate_cost(usage);
-    cost.saturating_add(SPEND_BUFFER_MICRO_CENTS) < remaining
 }
 
 #[cfg(test)]
@@ -479,6 +532,7 @@ mod tests {
         config: ChatConfig,
         append: Option<MessageParam>,
         outcome: Result<TurnOutcome>,
+        budget_usage: Option<Usage>,
     }
 
     impl StubAgent {
@@ -491,7 +545,13 @@ mod tests {
                 config,
                 append,
                 outcome,
+                budget_usage: None,
             }
+        }
+
+        fn with_budget_usage(mut self, usage: Usage) -> Self {
+            self.budget_usage = Some(usage);
+            self
         }
     }
 
@@ -501,9 +561,13 @@ mod tests {
             &mut self,
             _client: &Anthropic,
             messages: &mut Vec<MessageParam>,
-            _budget: &Arc<Budget>,
+            budget: &Arc<Budget>,
             _renderer: &mut dyn Renderer,
         ) -> Result<TurnOutcome> {
+            if let Some(usage) = self.budget_usage {
+                let mut allocation = budget.allocate_available(self.config.max_tokens()).unwrap();
+                assert!(allocation.consume_response(&usage));
+            }
             if let Some(message) = self.append.clone() {
                 crate::push_or_merge_message(messages, message);
             }
@@ -682,22 +746,61 @@ mod tests {
     }
 
     #[test]
-    fn spend_allows_next_turn_without_usage() {
-        let budget = Budget::new_with_rates(1000, 1, 1, 0, 0);
-        assert!(spend_allows_next_turn(&budget, None));
+    fn same_budget_state_matches_shared_budget_clones() {
+        let budget = Budget::new_with_rates(1000, 1, 2, 3, 4);
+        let cloned = budget.clone();
+        budget.consume_usage_saturating(&Usage::new(10, 20));
+
+        assert!(same_budget_state(Some(&budget), Some(&cloned)));
     }
 
     #[test]
-    fn spend_allows_next_turn_with_usage() {
-        let budget = Budget::new_with_rates(1000, 1, 1, 0, 0);
-        let usage = Usage::new(400, 0);
-        assert!(spend_allows_next_turn(&budget, Some(&usage)));
+    fn same_budget_state_detects_different_rates() {
+        let left = Budget::new_with_rates(1000, 1, 2, 3, 4);
+        let right = Budget::new_with_rates(1000, 1, 5, 3, 4);
+
+        assert!(!same_budget_state(Some(&left), Some(&right)));
     }
 
-    #[test]
-    fn spend_blocks_next_turn_when_over_grace() {
-        let budget = Budget::new_with_rates(100, 1, 1, 0, 0);
-        let usage = Usage::new(100, 0);
-        assert!(!spend_allows_next_turn(&budget, Some(&usage)));
+    #[tokio::test]
+    async fn session_spend_budget_survives_rebuild() {
+        let spend = Budget::new_flat_rate(1000, 10);
+        let usage = Usage::new(0, 40);
+        let client = Anthropic::new(None).unwrap();
+        let agent = StubAgent::new(
+            ChatConfig::default().with_session_spend_budget(Some(spend)),
+            Some(MessageParam::assistant("charged response")),
+            Ok(TurnOutcome {
+                stop_reason: crate::StopReason::EndTurn,
+                usage,
+                request_count: 1,
+            }),
+        )
+        .with_budget_usage(usage);
+        let mut session = ChatSession::with_agent(client, agent);
+        let mut renderer = TestRenderer;
+
+        session
+            .send_message(MessageParam::user("charge spend"), &mut renderer)
+            .await
+            .unwrap();
+
+        let stats = session.stats();
+        assert_eq!(stats.spend_used_micro_cents, 400);
+
+        let preserved_spend = session.session_spend_budget().unwrap();
+        let rebuilt_client = Anthropic::new(None).unwrap();
+        let rebuilt_agent = StubAgent::new(
+            ChatConfig::default().with_session_spend_budget(Some(preserved_spend)),
+            None,
+            Ok(TurnOutcome {
+                stop_reason: crate::StopReason::EndTurn,
+                usage: Usage::new(0, 0),
+                request_count: 0,
+            }),
+        );
+        let rebuilt = ChatSession::with_agent(rebuilt_client, rebuilt_agent);
+
+        assert_eq!(rebuilt.stats().spend_used_micro_cents, 400);
     }
 }

--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -474,7 +474,10 @@ mod tests {
 
     #[test]
     fn token_rates_sonnet_45() {
-        for model in [KnownModel::ClaudeSonnet45, KnownModel::ClaudeSonnet4520250929] {
+        for model in [
+            KnownModel::ClaudeSonnet45,
+            KnownModel::ClaudeSonnet4520250929,
+        ] {
             let rates = model.token_rates();
             assert_eq!(rates.input, 300);
             assert_eq!(rates.output, 1500);


### PR DESCRIPTION
Replace the post-turn consume_usage_saturating pattern with direct
use of the session spend Budget as the turn budget. This eliminates
double-counting and gives the agent accurate remaining-token caps.

Key changes:
- Add Budget::allocate_available to cap allocation to remaining funds
  instead of rejecting when full max_tokens cannot be funded
- Add Budget::remaining_output_tokens for checking fundable capacity
- Extract allocate_micro_cents as a shared CAS-loop helper
- Charge input-cost deficit to the allocation in consume_response so
  total budget accounting saturates correctly at zero
- Track session spend as Arc<Budget> in ChatSession and pass it
  directly as the turn budget, removing the separate post-turn charge
- Add set_session_spend, set_session_spend_budget, and
  session_spend_budget APIs for preserving spend state across session
  rebuilds
- Replace spend_allows_next_turn heuristic with a simple
  remaining_output_tokens() == 0 check

Co-authored-by: AI
