### PR TITLE
feat: add Claude Opus 4.8 model variant

### DIFF
--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -69,6 +69,9 @@ pub enum KnownModel {
     /// Claude Opus 4.7 (alias)
     ClaudeOpus47,
 
+    /// Claude Opus 4.8 (alias)
+    ClaudeOpus48,
+
     /// Claude 3 Opus (latest version)
     Claude3OpusLatest,
 
@@ -139,7 +142,7 @@ impl KnownModel {
     ///
     /// # Panics
     ///
-    /// If a model other than Haiku 4.5, Sonnet 4.5, or Opus 4.5, 4.6, or 4.7 is self.
+    /// If a model other than Haiku 4.5, Sonnet 4.5, or Opus 4.5, 4.6, 4.7, or 4.8 is self.
     pub fn token_rates(&self) -> TokenRates {
         match self {
             // Claude Haiku 4.5 — $0.80/$4, $1.00/$0.08
@@ -179,7 +182,8 @@ impl KnownModel {
             KnownModel::ClaudeOpus4520251101
             | KnownModel::ClaudeOpus45
             | KnownModel::ClaudeOpus46
-            | KnownModel::ClaudeOpus47 => TokenRates {
+            | KnownModel::ClaudeOpus47
+            | KnownModel::ClaudeOpus48 => TokenRates {
                 input: 500,
                 output: 2500,
                 cache_creation: 625,
@@ -211,6 +215,7 @@ impl fmt::Display for KnownModel {
             KnownModel::Claude4Opus20250514 => write!(f, "claude-4-opus-20250514"),
             KnownModel::ClaudeOpus4120250805 => write!(f, "claude-opus-4-1-20250805"),
             KnownModel::ClaudeOpus47 => write!(f, "claude-opus-4-7"),
+            KnownModel::ClaudeOpus48 => write!(f, "claude-opus-4-8"),
             KnownModel::Claude3OpusLatest => write!(f, "claude-3-opus-latest"),
             KnownModel::Claude3Opus20240229 => write!(f, "claude-3-opus-20240229"),
             KnownModel::Claude3Haiku20240307 => write!(f, "claude-3-haiku-20240307"),
@@ -254,6 +259,7 @@ impl<'de> Deserialize<'de> for Model {
             "claude-4-opus-20250514" => Ok(Model::Known(KnownModel::Claude4Opus20250514)),
             "claude-opus-4-1-20250805" => Ok(Model::Known(KnownModel::ClaudeOpus4120250805)),
             "claude-opus-4-7" => Ok(Model::Known(KnownModel::ClaudeOpus47)),
+            "claude-opus-4-8" => Ok(Model::Known(KnownModel::ClaudeOpus48)),
             "claude-3-opus-latest" => Ok(Model::Known(KnownModel::Claude3OpusLatest)),
             "claude-3-opus-20240229" => Ok(Model::Known(KnownModel::Claude3Opus20240229)),
             "claude-3-haiku-20240307" => Ok(Model::Known(KnownModel::Claude3Haiku20240307)),
@@ -291,6 +297,7 @@ impl FromStr for KnownModel {
             "claude-4-opus-20250514" => Ok(KnownModel::Claude4Opus20250514),
             "claude-opus-4-1-20250805" => Ok(KnownModel::ClaudeOpus4120250805),
             "claude-opus-4-7" => Ok(KnownModel::ClaudeOpus47),
+            "claude-opus-4-8" => Ok(KnownModel::ClaudeOpus48),
             "claude-3-opus-latest" => Ok(KnownModel::Claude3OpusLatest),
             "claude-3-opus-20240229" => Ok(KnownModel::Claude3Opus20240229),
             "claude-3-haiku-20240307" => Ok(KnownModel::Claude3Haiku20240307),
@@ -453,6 +460,20 @@ mod tests {
     }
 
     #[test]
+    fn claude_48_models() {
+        // Test Claude Opus 4.8 model
+        let model = Model::Known(KnownModel::ClaudeOpus48);
+        assert_eq!(model.to_string(), "claude-opus-4-8");
+        let json = serde_json::to_string(&model).unwrap();
+        assert_eq!(json, r#""claude-opus-4-8""#);
+
+        // Test deserialization of Claude 4.8 model
+        let json = r#""claude-opus-4-8""#;
+        let model: Model = serde_json::from_str(json).unwrap();
+        assert_eq!(model, Model::Known(KnownModel::ClaudeOpus48));
+    }
+
+    #[test]
     fn display() {
         let model = Model::Known(KnownModel::Claude37SonnetLatest);
         assert_eq!(model.to_string(), "claude-3-7-sonnet-latest");
@@ -474,7 +495,10 @@ mod tests {
 
     #[test]
     fn token_rates_sonnet_45() {
-        for model in [KnownModel::ClaudeSonnet45, KnownModel::ClaudeSonnet4520250929] {
+        for model in [
+            KnownModel::ClaudeSonnet45,
+            KnownModel::ClaudeSonnet4520250929,
+        ] {
             let rates = model.token_rates();
             assert_eq!(rates.input, 300);
             assert_eq!(rates.output, 1500);
@@ -490,6 +514,7 @@ mod tests {
             KnownModel::ClaudeOpus45,
             KnownModel::ClaudeOpus46,
             KnownModel::ClaudeOpus47,
+            KnownModel::ClaudeOpus48,
         ] {
             let rates = model.token_rates();
             assert_eq!(rates.input, 500);


### PR DESCRIPTION
Add ClaudeOpus48 to KnownModel with the model string
"claude-opus-4-8". Wire it through Display, Deserialize,
and FromStr implementations, and assign the same token rates
as the other Opus 4.x models. Include a dedicated test for
round-trip serialization and add the variant to the existing
token_rates test matrix.

Co-authored-by: AI
