### PR TITLE
chore: bump version to 0.31.0 and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2024"
 description = "SDK for the Anthropic API"
@@ -16,27 +16,27 @@ rustls-tls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
 
 [dependencies]
-async-trait = "0.1"
-base64 = "0.22"
-bytes = "1.11"
-ctrlc = { version = "3.5", features = ["termination"] }
-futures = "0.3"
-getopts = "0.2"
-libc = "0.2"
-reqwest = { version = "0.13", default-features = false, features = ["json", "query", "stream"] }
-rustyline = "17.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
-serde_yaml = "0.9"
-time = { version = "0.3", features = ["serde", "macros", "formatting", "parsing"] }
-tokio = { version = "^1.49", features = ["full"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-url = "2.5"
+async-trait = "0.1.89"
+base64 = "0.22.1"
+bytes = "1.11.1"
+ctrlc = { version = "3.5.2", features = ["termination"] }
+futures = "0.3.32"
+getopts = "0.2.24"
+libc = "0.2.186"
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "query", "stream"] }
+rustyline = "18.0.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+serde_yaml = "0.9.34"
+time = { version = "0.3.47", features = ["serde", "macros", "formatting", "parsing"] }
+tokio = { version = "1.52.3", features = ["full"] }
+tokio-util = { version = "0.7.18", features = ["codec"] }
+url = "2.5.8"
 
-arrrg = "^0.9"
-arrrg_derive = "^0.9"
-biometrics = "^0.13"
-utf8path = "^0.10"
+arrrg = "0.10.0"
+arrrg_derive = "0.10.0"
+biometrics = "0.14.0"
+utf8path = "0.11.0"
 
 [[bin]]
 name = "median-text"
@@ -54,7 +54,7 @@ path = "src/bin/claudius-chat.rs"
 required-features=["binaries"]
 
 [dev-dependencies]
-tokio = { version = "1.49.0", features = ["full", "test-util", "macros"] }
+tokio = { version = "1.52.3", features = ["full", "test-util", "macros"] }
 tokio-test = "0.4.5"
 
 [[example]]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2380,7 +2380,7 @@ impl FileSystem for Path<'_> {
 
     async fn list_directory(&self, path: &str) -> Result<Option<String>, std::io::Error> {
         let path = sanitize_path(self.clone(), path)?;
-        if path.is_dir() {
+        if path.is_dir().unwrap_or(false) {
             Ok(Some(directory_listing(&path)?))
         } else {
             Ok(None)
@@ -2394,7 +2394,7 @@ impl FileSystem for Path<'_> {
     ) -> Result<String, std::io::Error> {
         validate_view_range(view_range)?;
         let path = sanitize_path(self.clone(), path)?;
-        if path.is_file() {
+        if path.is_file().unwrap_or(false) {
             let content = std::fs::read_to_string(path)?;
             let lines = content
                 .split('\n')
@@ -2409,7 +2409,7 @@ impl FileSystem for Path<'_> {
             let mut ret = lines.join("\n");
             ret.push('\n');
             Ok(ret)
-        } else if path.is_dir() {
+        } else if path.is_dir().unwrap_or(false) {
             directory_listing(&path)
         } else {
             Err(std::io::Error::new(
@@ -2426,7 +2426,7 @@ impl FileSystem for Path<'_> {
         new_str: &str,
     ) -> Result<String, std::io::Error> {
         let path = sanitize_path(self.clone(), path)?;
-        if path.is_file() {
+        if path.is_file().unwrap_or(false) {
             let content = std::fs::read_to_string(&path)?;
             let count = content.matches(old_str).count();
             if count == 0 {
@@ -2459,7 +2459,7 @@ impl FileSystem for Path<'_> {
         insert_text: &str,
     ) -> Result<String, std::io::Error> {
         let path = sanitize_path(self.clone(), path)?;
-        if path.is_file() {
+        if path.is_file().unwrap_or(false) {
             let content = std::fs::read_to_string(&path)?;
             let mut lines = content
                 .split_terminator('\n')
@@ -2496,7 +2496,7 @@ impl FileSystem for Path<'_> {
     /// Returns other I/O errors if file creation fails for other reasons.
     async fn create(&self, path: &str, file_text: &str) -> Result<String, std::io::Error> {
         let path = sanitize_path(self.clone(), path)?;
-        if !path.exists() {
+        if !path.exists().unwrap_or(false) {
             std::fs::create_dir_all(path.dirname())?;
             std::fs::write(&path, file_text)?;
             Ok("success".to_string())


### PR DESCRIPTION
Pin all dependency versions to exact patch releases and bump
major dependency updates:
- rustyline: 17.0 -> 18.0.0
- arrrg/arrrg_derive: 0.9 -> 0.10.0
- biometrics: 0.13 -> 0.14.0
- utf8path: 0.10 -> 0.11.0
- tokio: 1.49 -> 1.52.3

Adapt agent.rs to utf8path 0.11 API changes where is_dir(),
is_file(), and exists() now return Result instead of bool,
using unwrap_or(false) to preserve existing behavior.

Co-authored-by: AI
