### PR TITLE
feat(batch): add Message Batches API support

### DIFF
--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,0 +1,124 @@
+use std::env;
+use std::time::Duration;
+
+use claudius::{
+    Anthropic, KnownModel, MessageBatch, MessageBatchCreateParams, MessageBatchCreateRequest,
+    MessageBatchProcessingStatus, MessageBatchResult, MessageBatchResultVariant,
+    MessageCreateParams, Result,
+};
+use futures::StreamExt;
+use tokio::pin;
+use tokio::time::sleep;
+
+// Anthropic's batch-processing guide polls once per minute.
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Anthropic::new(None)?;
+
+    let batch_id = match env::args().nth(1) {
+        Some(batch_id) => {
+            println!("Polling existing Message Batch: {batch_id}");
+            batch_id
+        }
+        None => {
+            let batch = create_demo_batch(&client).await?;
+            println!("Created Message Batch: {}", batch.id);
+            batch.id
+        }
+    };
+
+    let batch = poll_until_ended(&client, &batch_id).await?;
+
+    println!();
+    println!("Batch ended:");
+    print_batch_status(&batch);
+
+    println!();
+    println!("Streaming results:");
+    let results = client.stream_message_batch_results(&batch.id).await?;
+    pin!(results);
+
+    while let Some(result) = results.next().await {
+        print_result(&result?);
+    }
+
+    Ok(())
+}
+
+async fn create_demo_batch(client: &Anthropic) -> Result<MessageBatch> {
+    let requests = vec![
+        MessageBatchCreateRequest::new(
+            "batch-example-summary",
+            MessageCreateParams::simple(
+                "Explain message batch processing in one sentence.",
+                KnownModel::ClaudeHaiku45,
+            ),
+        ),
+        MessageBatchCreateRequest::new(
+            "batch-example-list",
+            MessageCreateParams::simple(
+                "List three practical use cases for asynchronous batch processing.",
+                KnownModel::ClaudeHaiku45,
+            ),
+        ),
+    ];
+
+    client
+        .create_message_batch(MessageBatchCreateParams::new(requests))
+        .await
+}
+
+async fn poll_until_ended(client: &Anthropic, batch_id: &str) -> Result<MessageBatch> {
+    loop {
+        let batch = client.retrieve_message_batch(batch_id).await?;
+        print_batch_status(&batch);
+
+        if batch.processing_status == MessageBatchProcessingStatus::Ended {
+            return Ok(batch);
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn print_batch_status(batch: &MessageBatch) {
+    println!(
+        "{}: {:?} | processing={} succeeded={} errored={} canceled={} expired={}",
+        batch.id,
+        batch.processing_status,
+        batch.request_counts.processing,
+        batch.request_counts.succeeded,
+        batch.request_counts.errored,
+        batch.request_counts.canceled,
+        batch.request_counts.expired
+    );
+}
+
+fn print_result(result: &MessageBatchResult) {
+    match &result.result {
+        MessageBatchResultVariant::Succeeded { message } => {
+            println!("{} succeeded with message {}", result.custom_id, message.id);
+            for block in &message.content {
+                if let Some(text) = block.as_text() {
+                    println!("{}", text.text);
+                } else {
+                    println!("{block:?}");
+                }
+            }
+        }
+        MessageBatchResultVariant::Errored { error } => {
+            println!(
+                "{} errored: {}: {}",
+                result.custom_id, error.error.r#type, error.error.message
+            );
+        }
+        MessageBatchResultVariant::Canceled => {
+            println!("{} was canceled", result.custom_id);
+        }
+        MessageBatchResultVariant::Expired => {
+            println!("{} expired", result.custom_id);
+        }
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -2092,11 +2092,11 @@ Connection: close\r\n\r\n",
             socket.write_all(response_headers.as_bytes()).await.unwrap();
             let split_at = results_body.find('\n').unwrap() + 1;
             socket
-                .write_all(results_body[..split_at].as_bytes())
+                .write_all(&results_body.as_bytes()[..split_at])
                 .await
                 .unwrap();
             socket
-                .write_all(results_body[split_at..].as_bytes())
+                .write_all(&results_body.as_bytes()[split_at..])
                 .await
                 .unwrap();
             socket.shutdown().await.unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::env;
 use std::error::Error as StdError;
 use std::fs;
@@ -6,7 +7,8 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use futures::Stream;
+use bytes::Bytes;
+use futures::{Stream, StreamExt, stream};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client as ReqwestClient, Response, header};
 use serde::Deserialize;
@@ -22,8 +24,9 @@ use crate::observability::{
 };
 use crate::sse::process_message_stream_sse;
 use crate::types::{
-    Message, MessageCountTokensParams, MessageCreateParams, MessageStreamEvent, MessageTokensCount,
-    ModelInfo, ModelListParams, ModelListResponse,
+    DeletedMessageBatch, Message, MessageBatch, MessageBatchCreateParams, MessageBatchListParams,
+    MessageBatchListResponse, MessageBatchResult, MessageCountTokensParams, MessageCreateParams,
+    MessageStreamEvent, MessageTokensCount, ModelInfo, ModelListParams, ModelListResponse,
 };
 
 /// A stream wrapper that logs events and the final message through a [`ClientLogger`].
@@ -94,6 +97,131 @@ fn format_reqwest_error(err: &reqwest::Error) -> String {
         source = inner.source();
     }
     parts.join(": ")
+}
+
+const MAX_MESSAGE_BATCH_RESULT_LINE_BYTES: usize = 64 * 1024 * 1024;
+
+struct MessageBatchJsonlState<S> {
+    byte_stream: S,
+    buffer: Vec<u8>,
+    pending_lines: VecDeque<Vec<u8>>,
+    finished: bool,
+}
+
+fn map_batch_result_stream_error(err: reqwest::Error) -> Error {
+    let details = format_reqwest_error(&err);
+    if err.is_timeout() {
+        Error::timeout(
+            format!("Message batch results stream timed out: {details}"),
+            None,
+        )
+    } else if err.is_connect() {
+        Error::connection(
+            format!("Message batch results stream connection error: {details}"),
+            Some(Box::new(err)),
+        )
+    } else {
+        Error::streaming(
+            format!("Error in message batch results stream: {details}"),
+            Some(Box::new(err)),
+        )
+    }
+}
+
+fn parse_message_batch_result_line(line: &[u8]) -> Result<MessageBatchResult> {
+    let text = std::str::from_utf8(line).map_err(|e| {
+        Error::encoding(
+            format!("Invalid UTF-8 in message batch results JSONL: {e}"),
+            Some(Box::new(e)),
+        )
+    })?;
+
+    serde_json::from_str::<MessageBatchResult>(text).map_err(|e| {
+        Error::serialization(
+            format!("Failed to parse message batch results JSONL line: {e}"),
+            Some(Box::new(e)),
+        )
+    })
+}
+
+fn trim_jsonl_line(mut line: Vec<u8>) -> Vec<u8> {
+    if line.ends_with(b"\n") {
+        line.pop();
+    }
+    if line.ends_with(b"\r") {
+        line.pop();
+    }
+    line
+}
+
+fn process_message_batch_result_jsonl<S>(
+    byte_stream: S,
+) -> impl Stream<Item = Result<MessageBatchResult>>
+where
+    S: Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Unpin + 'static,
+{
+    let state = MessageBatchJsonlState {
+        byte_stream,
+        buffer: Vec::new(),
+        pending_lines: VecDeque::new(),
+        finished: false,
+    };
+
+    stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(line) = state.pending_lines.pop_front() {
+                if line.is_empty() {
+                    continue;
+                }
+                return Some((parse_message_batch_result_line(&line), state));
+            }
+
+            if state.finished {
+                if state.buffer.is_empty() {
+                    return None;
+                }
+                let line = trim_jsonl_line(std::mem::take(&mut state.buffer));
+                if line.is_empty() {
+                    continue;
+                }
+                return Some((parse_message_batch_result_line(&line), state));
+            }
+
+            match state.byte_stream.next().await {
+                Some(Ok(bytes)) => {
+                    state.buffer.extend_from_slice(&bytes);
+                    if state.buffer.len() > MAX_MESSAGE_BATCH_RESULT_LINE_BYTES {
+                        state.buffer.clear();
+                        state.finished = true;
+                        return Some((
+                            Err(Error::streaming(
+                                format!(
+                                    "Message batch results JSONL line exceeded maximum size of {} bytes",
+                                    MAX_MESSAGE_BATCH_RESULT_LINE_BYTES
+                                ),
+                                None,
+                            )),
+                            state,
+                        ));
+                    }
+
+                    while let Some(newline) = state.buffer.iter().position(|byte| *byte == b'\n') {
+                        let line = trim_jsonl_line(state.buffer.drain(..=newline).collect());
+                        if !line.is_empty() {
+                            state.pending_lines.push_back(line);
+                        }
+                    }
+                }
+                Some(Err(err)) => {
+                    state.finished = true;
+                    return Some((Err(map_batch_result_stream_error(err)), state));
+                }
+                None => {
+                    state.finished = true;
+                }
+            }
+        }
+    })
 }
 
 /// Client for the Anthropic API with performance optimizations.
@@ -614,6 +742,89 @@ impl Anthropic {
         })
     }
 
+    /// Execute an empty-body POST request with error handling.
+    async fn execute_post_empty_request<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        headers: Option<HeaderMap>,
+    ) -> Result<T> {
+        let headers = headers.unwrap_or_else(|| self.default_headers());
+
+        let response = self
+            .client
+            .post(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| self.map_request_error(e))?;
+
+        if !response.status().is_success() {
+            return Err(Self::process_error_response(response).await);
+        }
+
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| self.map_response_body_error(e))?;
+
+        serde_json::from_slice::<T>(&body).map_err(|e| {
+            Error::serialization(format!("Failed to parse response: {e}"), Some(Box::new(e)))
+        })
+    }
+
+    /// Execute a DELETE request with error handling.
+    async fn execute_delete_request<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        headers: Option<HeaderMap>,
+    ) -> Result<T> {
+        let headers = headers.unwrap_or_else(|| self.default_headers());
+
+        let response = self
+            .client
+            .delete(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| self.map_request_error(e))?;
+
+        if !response.status().is_success() {
+            return Err(Self::process_error_response(response).await);
+        }
+
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| self.map_response_body_error(e))?;
+
+        serde_json::from_slice::<T>(&body).map_err(|e| {
+            Error::serialization(format!("Failed to parse response: {e}"), Some(Box::new(e)))
+        })
+    }
+
+    /// Execute a streaming GET request with error handling.
+    async fn execute_get_stream_request(
+        &self,
+        url: &str,
+        headers: Option<HeaderMap>,
+    ) -> Result<Response> {
+        let headers = headers.unwrap_or_else(|| self.default_headers());
+
+        let response = self
+            .client
+            .get(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| self.map_request_error(e))?;
+
+        if !response.status().is_success() {
+            return Err(Self::process_error_response(response).await);
+        }
+
+        Ok(response)
+    }
+
     /// Send a message to the API and get a non-streaming response.
     pub async fn send(&self, mut params: MessageCreateParams) -> Result<Message> {
         let start = Instant::now();
@@ -799,6 +1010,206 @@ impl Anthropic {
         result
     }
 
+    /// Create a Message Batch for asynchronous processing.
+    pub async fn create_message_batch(
+        &self,
+        params: MessageBatchCreateParams,
+    ) -> Result<MessageBatch> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        if let Err(err) = params.validate() {
+            CLIENT_REQUEST_ERRORS.click();
+            CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+            return Err(err);
+        }
+
+        let mut request_betas = Vec::new();
+        if let Some(betas) = &params.betas {
+            request_betas.extend(betas.iter().cloned());
+        }
+        for request in &params.requests {
+            if let Some(betas) = &request.params.betas {
+                request_betas.extend(betas.iter().cloned());
+            }
+        }
+
+        let auto_betas: Vec<&str> = if params
+            .requests
+            .iter()
+            .any(|request| request.params.requires_structured_outputs_beta())
+        {
+            vec![STRUCTURED_OUTPUTS_BETA]
+        } else {
+            vec![]
+        };
+        let all_betas = if request_betas.is_empty() {
+            self.collect_betas(None, &auto_betas)
+        } else {
+            self.collect_betas(Some(&request_betas), &auto_betas)
+        };
+        let headers = self.headers_with_betas(&all_betas);
+
+        let result = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url("messages/batches");
+                self.execute_post_request(&url, &params, headers.clone())
+                    .await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        if result.is_err() {
+            CLIENT_REQUEST_ERRORS.click();
+        }
+        result
+    }
+
+    /// Retrieve a Message Batch by ID.
+    pub async fn get_message_batch(&self, message_batch_id: &str) -> Result<MessageBatch> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        let all_betas = self.collect_betas(None, &[]);
+        let headers = self.headers_with_betas(&all_betas);
+
+        let result = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url(&format!("messages/batches/{message_batch_id}"));
+                self.execute_get_request(&url, None, headers.clone()).await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        if result.is_err() {
+            CLIENT_REQUEST_ERRORS.click();
+        }
+        result
+    }
+
+    /// Retrieve a Message Batch by ID.
+    pub async fn retrieve_message_batch(&self, message_batch_id: &str) -> Result<MessageBatch> {
+        self.get_message_batch(message_batch_id).await
+    }
+
+    /// List Message Batches in the current Workspace.
+    pub async fn list_message_batches(
+        &self,
+        params: Option<MessageBatchListParams>,
+    ) -> Result<MessageBatchListResponse> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        let request_betas = params.as_ref().and_then(|p| p.betas.as_deref());
+        let all_betas = self.collect_betas(request_betas, &[]);
+        let headers = self.headers_with_betas(&all_betas);
+
+        let result = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url("messages/batches");
+                let query_params = params.as_ref().map(|p| {
+                    let mut params = Vec::new();
+                    if let Some(ref after_id) = p.after_id {
+                        params.push(("after_id".to_string(), after_id.clone()));
+                    }
+                    if let Some(ref before_id) = p.before_id {
+                        params.push(("before_id".to_string(), before_id.clone()));
+                    }
+                    if let Some(limit) = p.limit {
+                        params.push(("limit".to_string(), limit.to_string()));
+                    }
+                    params
+                });
+
+                self.execute_get_request(&url, query_params.as_deref(), headers.clone())
+                    .await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        if result.is_err() {
+            CLIENT_REQUEST_ERRORS.click();
+        }
+        result
+    }
+
+    /// Cancel a Message Batch that is currently processing.
+    pub async fn cancel_message_batch(&self, message_batch_id: &str) -> Result<MessageBatch> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        let all_betas = self.collect_betas(None, &[]);
+        let headers = self.headers_with_betas(&all_betas);
+
+        let result = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url(&format!("messages/batches/{message_batch_id}/cancel"));
+                self.execute_post_empty_request(&url, headers.clone()).await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        if result.is_err() {
+            CLIENT_REQUEST_ERRORS.click();
+        }
+        result
+    }
+
+    /// Delete a Message Batch after processing has ended.
+    pub async fn delete_message_batch(
+        &self,
+        message_batch_id: &str,
+    ) -> Result<DeletedMessageBatch> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        let all_betas = self.collect_betas(None, &[]);
+        let headers = self.headers_with_betas(&all_betas);
+
+        let result = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url(&format!("messages/batches/{message_batch_id}"));
+                self.execute_delete_request(&url, headers.clone()).await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        if result.is_err() {
+            CLIENT_REQUEST_ERRORS.click();
+        }
+        result
+    }
+
+    /// Stream results for an ended Message Batch as JSONL records.
+    pub async fn stream_message_batch_results(
+        &self,
+        message_batch_id: &str,
+    ) -> Result<impl Stream<Item = Result<MessageBatchResult>> + use<>> {
+        let start = Instant::now();
+        CLIENT_REQUESTS.click();
+
+        let all_betas = self.collect_betas(None, &[]);
+        let headers = self.headers_with_betas(&all_betas);
+
+        let response = self
+            .retry_with_backoff(|| async {
+                let url = self.build_url(&format!("messages/batches/{message_batch_id}/results"));
+                self.execute_get_stream_request(&url, headers.clone()).await
+            })
+            .await;
+
+        CLIENT_REQUEST_DURATION.add(start.elapsed().as_secs_f64());
+        let response = match response {
+            Ok(response) => response,
+            Err(err) => {
+                CLIENT_REQUEST_ERRORS.click();
+                return Err(err);
+            }
+        };
+
+        Ok(process_message_batch_result_jsonl(response.bytes_stream()))
+    }
+
     /// List available models from the API.
     ///
     /// Returns a paginated list of all available models. Use the parameters to control
@@ -867,8 +1278,12 @@ impl Anthropic {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{KnownModel, MessageParam, Model};
+    use crate::{
+        KnownModel, MessageBatchCreateParams, MessageBatchCreateRequest, MessageBatchListParams,
+        MessageBatchResultVariant, MessageParam, Model,
+    };
     use futures::StreamExt;
+    use serde_json::Value;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -878,7 +1293,7 @@ mod tests {
         buffer.windows(4).position(|window| window == b"\r\n\r\n")
     }
 
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+    async fn read_http_request_bytes(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
         let mut buffer = Vec::new();
         let mut chunk = [0_u8; 1024];
         loop {
@@ -915,6 +1330,56 @@ mod tests {
             );
             buffer.extend_from_slice(&chunk[..read]);
         }
+        buffer
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+        read_http_request_bytes(socket).await;
+    }
+
+    fn split_http_request(request: &[u8]) -> (String, String) {
+        let headers_end = request_headers_end(request).unwrap();
+        let headers = String::from_utf8_lossy(&request[..headers_end]).to_string();
+        let body = String::from_utf8_lossy(&request[headers_end + 4..]).to_string();
+        (headers, body)
+    }
+
+    fn request_target(headers: &str) -> &str {
+        headers
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap()
+    }
+
+    fn request_method(headers: &str) -> &str {
+        headers
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().next())
+            .unwrap()
+    }
+
+    fn header_value<'a>(headers: &'a str, name: &str) -> Option<&'a str> {
+        headers.lines().find_map(|line| {
+            let mut parts = line.splitn(2, ':');
+            let header_name = parts.next()?.trim();
+            let value = parts.next()?.trim();
+            header_name.eq_ignore_ascii_case(name).then_some(value)
+        })
+    }
+
+    async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\n\
+Content-Type: application/json\r\n\
+Content-Length: {}\r\n\
+Connection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.shutdown().await.unwrap();
     }
 
     async fn start_test_server<F, Fut>(handler: F) -> String
@@ -1388,6 +1853,277 @@ mod tests {
     fn with_default_betas_builder() {
         let client = test_client().with_default_betas(["a", "b", "c"]);
         assert_eq!(client.default_betas, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn create_message_batch_posts_expected_body_and_betas() {
+        let response_body = r#"{
+            "id": "msgbatch_123",
+            "type": "message_batch",
+            "processing_status": "in_progress",
+            "request_counts": {
+                "processing": 1,
+                "succeeded": 0,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0
+            },
+            "ended_at": null,
+            "created_at": "2024-09-24T18:37:24Z",
+            "expires_at": "2024-09-25T18:37:24Z",
+            "cancel_initiated_at": null,
+            "results_url": null
+        }"#;
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "POST");
+            assert_eq!(request_target(&headers), "/v1/messages/batches");
+            assert_eq!(
+                header_value(&headers, "anthropic-beta"),
+                Some("default-beta, batch-beta, request-beta")
+            );
+
+            let body_json: Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(body_json["requests"][0]["custom_id"], "request-1");
+            assert_eq!(
+                body_json["requests"][0]["params"]["model"],
+                "claude-haiku-4-5"
+            );
+            assert!(
+                body_json["requests"][0]["params"].get("stream").is_none(),
+                "stream must not be serialized inside batch params"
+            );
+            assert!(body_json.get("betas").is_none());
+
+            write_json_response(&mut socket, response_body).await;
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url)
+            .with_default_betas(["default-beta"]);
+        let request_params = MessageCreateParams::new(
+            16,
+            vec![MessageParam::user("ping")],
+            Model::Known(KnownModel::ClaudeHaiku45),
+        )
+        .with_beta("request-beta");
+        let params = MessageBatchCreateParams::new(vec![MessageBatchCreateRequest::new(
+            "request-1",
+            request_params,
+        )])
+        .with_beta("batch-beta");
+
+        let batch = client.create_message_batch(params).await.unwrap();
+        assert_eq!(batch.id, "msgbatch_123");
+    }
+
+    #[tokio::test]
+    async fn get_message_batch_uses_retrieve_endpoint() {
+        let response_body = r#"{
+            "id": "msgbatch_123",
+            "type": "message_batch",
+            "processing_status": "ended",
+            "request_counts": {
+                "processing": 0,
+                "succeeded": 1,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0
+            },
+            "ended_at": "2024-09-24T18:39:24Z",
+            "created_at": "2024-09-24T18:37:24Z",
+            "expires_at": "2024-09-25T18:37:24Z",
+            "cancel_initiated_at": null,
+            "results_url": "https://api.anthropic.com/results"
+        }"#;
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "GET");
+            assert_eq!(
+                request_target(&headers),
+                "/v1/messages/batches/msgbatch_123"
+            );
+            assert!(body.is_empty());
+            write_json_response(&mut socket, response_body).await;
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url);
+        let batch = client.get_message_batch("msgbatch_123").await.unwrap();
+        assert_eq!(batch.id, "msgbatch_123");
+        assert_eq!(batch.request_counts.succeeded, 1);
+    }
+
+    #[tokio::test]
+    async fn list_message_batches_sends_pagination_query_and_beta() {
+        let response_body = r#"{
+            "data": [],
+            "has_more": false,
+            "first_id": null,
+            "last_id": null
+        }"#;
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "GET");
+            assert_eq!(
+                request_target(&headers),
+                "/v1/messages/batches?after_id=msgbatch_a&limit=20"
+            );
+            assert_eq!(header_value(&headers, "anthropic-beta"), Some("list-beta"));
+            assert!(body.is_empty());
+            write_json_response(&mut socket, response_body).await;
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url);
+        let params = MessageBatchListParams::new()
+            .with_after_id("msgbatch_a")
+            .with_limit(20)
+            .with_beta("list-beta");
+        let page = client.list_message_batches(Some(params)).await.unwrap();
+        assert!(page.data.is_empty());
+        assert!(!page.has_more);
+    }
+
+    #[tokio::test]
+    async fn cancel_message_batch_posts_empty_body() {
+        let response_body = r#"{
+            "id": "msgbatch_123",
+            "type": "message_batch",
+            "processing_status": "canceling",
+            "request_counts": {
+                "processing": 1,
+                "succeeded": 0,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0
+            },
+            "ended_at": null,
+            "created_at": "2024-09-24T18:37:24Z",
+            "expires_at": "2024-09-25T18:37:24Z",
+            "cancel_initiated_at": "2024-09-24T18:39:03Z",
+            "results_url": null
+        }"#;
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "POST");
+            assert_eq!(
+                request_target(&headers),
+                "/v1/messages/batches/msgbatch_123/cancel"
+            );
+            assert!(body.is_empty());
+            write_json_response(&mut socket, response_body).await;
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url);
+        let batch = client.cancel_message_batch("msgbatch_123").await.unwrap();
+        assert_eq!(batch.id, "msgbatch_123");
+    }
+
+    #[tokio::test]
+    async fn delete_message_batch_uses_delete_endpoint() {
+        let response_body = r#"{
+            "id": "msgbatch_123",
+            "type": "message_batch_deleted"
+        }"#;
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "DELETE");
+            assert_eq!(
+                request_target(&headers),
+                "/v1/messages/batches/msgbatch_123"
+            );
+            assert!(body.is_empty());
+            write_json_response(&mut socket, response_body).await;
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url);
+        let deleted = client.delete_message_batch("msgbatch_123").await.unwrap();
+        assert_eq!(deleted.r#type, "message_batch_deleted");
+    }
+
+    #[tokio::test]
+    async fn stream_message_batch_results_preserves_jsonl_order_without_trailing_newline() {
+        let results_body = concat!(
+            r#"{"custom_id":"second","result":{"type":"expired"}}"#,
+            "\n",
+            r#"{"custom_id":"first","result":{"type":"succeeded","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}}"#
+        );
+
+        let base_url = start_test_server(move |mut socket| async move {
+            let request = read_http_request_bytes(&mut socket).await;
+            let (headers, body) = split_http_request(&request);
+            assert_eq!(request_method(&headers), "GET");
+            assert_eq!(
+                request_target(&headers),
+                "/v1/messages/batches/msgbatch_123/results"
+            );
+            assert!(body.is_empty());
+
+            let response_headers = format!(
+                "HTTP/1.1 200 OK\r\n\
+Content-Type: application/jsonl\r\n\
+Content-Length: {}\r\n\
+Connection: close\r\n\r\n",
+                results_body.len()
+            );
+            socket.write_all(response_headers.as_bytes()).await.unwrap();
+            let split_at = results_body.find('\n').unwrap() + 1;
+            socket
+                .write_all(results_body[..split_at].as_bytes())
+                .await
+                .unwrap();
+            socket
+                .write_all(results_body[split_at..].as_bytes())
+                .await
+                .unwrap();
+            socket.shutdown().await.unwrap();
+        })
+        .await;
+
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_base_url(base_url);
+        let stream = client
+            .stream_message_batch_results("msgbatch_123")
+            .await
+            .unwrap();
+        let mut stream = std::pin::pin!(stream);
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.custom_id, "second");
+        assert!(matches!(first.result, MessageBatchResultVariant::Expired));
+
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.custom_id, "first");
+        assert!(matches!(
+            second.result,
+            MessageBatchResultVariant::Succeeded { .. }
+        ));
+
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]

--- a/src/types/message_batch.rs
+++ b/src/types/message_batch.rs
@@ -1,0 +1,807 @@
+use std::collections::HashSet;
+
+use serde::de::Error as DeError;
+use serde::ser::{SerializeStruct, Serializer};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::types::{Message, MessageCreateParams};
+
+const MAX_MESSAGE_BATCH_REQUESTS: usize = 100_000;
+const MAX_MESSAGE_BATCH_BODY_BYTES: usize = 256 * 1024 * 1024;
+
+/// Parameters for creating a Message Batch.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct MessageBatchCreateParams {
+    /// Individual Messages API requests to process asynchronously.
+    pub requests: Vec<MessageBatchCreateRequest>,
+
+    /// Beta feature headers to include with this batch request.
+    ///
+    /// These are sent as the `anthropic-beta` HTTP header and are not serialized
+    /// into the JSON request body.
+    #[serde(skip)]
+    pub betas: Option<Vec<String>>,
+}
+
+impl MessageBatchCreateParams {
+    /// Create batch creation parameters from individual batch requests.
+    pub fn new(requests: Vec<MessageBatchCreateRequest>) -> Self {
+        Self {
+            requests,
+            betas: None,
+        }
+    }
+
+    /// Set beta feature headers for this batch creation request.
+    pub fn with_betas(mut self, betas: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.betas = Some(betas.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Add a single beta feature header for this batch creation request.
+    pub fn with_beta(mut self, beta: impl Into<String>) -> Self {
+        self.betas.get_or_insert_with(Vec::new).push(beta.into());
+        self
+    }
+
+    /// Validate batch creation parameters before sending them to the API.
+    pub fn validate(&self) -> crate::Result<()> {
+        if self.requests.is_empty() {
+            return Err(crate::Error::validation(
+                "At least one batch request is required",
+                Some("requests".to_string()),
+            ));
+        }
+
+        if self.requests.len() > MAX_MESSAGE_BATCH_REQUESTS {
+            return Err(crate::Error::validation(
+                format!(
+                    "Batch request count {} exceeds limit of {}",
+                    self.requests.len(),
+                    MAX_MESSAGE_BATCH_REQUESTS
+                ),
+                Some("requests".to_string()),
+            ));
+        }
+
+        let mut custom_ids = HashSet::with_capacity(self.requests.len());
+        for (i, request) in self.requests.iter().enumerate() {
+            if !is_valid_custom_id(&request.custom_id) {
+                return Err(crate::Error::validation(
+                    "custom_id must be 1 to 64 characters and contain only alphanumeric characters, hyphens, and underscores",
+                    Some(format!("requests[{i}].custom_id")),
+                ));
+            }
+
+            if !custom_ids.insert(request.custom_id.as_str()) {
+                return Err(crate::Error::validation(
+                    format!("Duplicate custom_id: {}", request.custom_id),
+                    Some(format!("requests[{i}].custom_id")),
+                ));
+            }
+
+            if request.params.stream {
+                return Err(crate::Error::validation(
+                    "stream is not supported in message batch requests",
+                    Some(format!("requests[{i}].params.stream")),
+                ));
+            }
+
+            request.params.validate().map_err(|err| match err {
+                crate::Error::Validation { message, param } => crate::Error::validation(
+                    message,
+                    param.map(|param| format!("requests[{i}].params.{param}")),
+                ),
+                other => other,
+            })?;
+        }
+
+        let body = serde_json::to_vec(self).map_err(|e| {
+            crate::Error::serialization(
+                format!("Failed to serialize message batch create params: {e}"),
+                Some(Box::new(e)),
+            )
+        })?;
+        if body.len() > MAX_MESSAGE_BATCH_BODY_BYTES {
+            return Err(crate::Error::validation(
+                format!(
+                    "Serialized batch request size {} exceeds limit of {} bytes",
+                    body.len(),
+                    MAX_MESSAGE_BATCH_BODY_BYTES
+                ),
+                Some("requests".to_string()),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Serialize for MessageBatchCreateParams {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("MessageBatchCreateParams", 1)?;
+        state.serialize_field("requests", &self.requests)?;
+        state.end()
+    }
+}
+
+/// A single Messages API request within a Message Batch.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct MessageBatchCreateRequest {
+    /// Caller-provided identifier used to match results back to requests.
+    pub custom_id: String,
+
+    /// Non-streaming Messages API parameters for this individual request.
+    pub params: MessageCreateParams,
+}
+
+impl MessageBatchCreateRequest {
+    /// Create a batch request from a custom ID and message creation parameters.
+    pub fn new(custom_id: impl Into<String>, params: MessageCreateParams) -> Self {
+        Self {
+            custom_id: custom_id.into(),
+            params,
+        }
+    }
+}
+
+impl Serialize for MessageBatchCreateRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("MessageBatchCreateRequest", 2)?;
+        state.serialize_field("custom_id", &self.custom_id)?;
+        state.serialize_field("params", &MessageBatchRequestParams(&self.params))?;
+        state.end()
+    }
+}
+
+struct MessageBatchRequestParams<'a>(&'a MessageCreateParams);
+
+impl Serialize for MessageBatchRequestParams<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let params = self.0;
+        let mut len = 3;
+        len += usize::from(params.cache_control.is_some());
+        len += usize::from(params.metadata.is_some());
+        len += usize::from(params.output_format.is_some());
+        len += usize::from(params.output_config.is_some());
+        len += usize::from(params.stop_sequences.is_some());
+        len += usize::from(params.system.is_some());
+        len += usize::from(params.temperature.is_some());
+        len += usize::from(params.thinking.is_some());
+        len += usize::from(params.tool_choice.is_some());
+        len += usize::from(params.tools.is_some());
+        len += usize::from(params.top_k.is_some());
+        len += usize::from(params.top_p.is_some());
+
+        let mut state = serializer.serialize_struct("MessageBatchRequestParams", len)?;
+        state.serialize_field("max_tokens", &params.max_tokens)?;
+        state.serialize_field("messages", &params.messages)?;
+        state.serialize_field("model", &params.model)?;
+        if let Some(cache_control) = &params.cache_control {
+            state.serialize_field("cache_control", cache_control)?;
+        }
+        if let Some(metadata) = &params.metadata {
+            state.serialize_field("metadata", metadata)?;
+        }
+        if let Some(output_format) = &params.output_format {
+            state.serialize_field("output_format", output_format)?;
+        }
+        if let Some(output_config) = &params.output_config {
+            state.serialize_field("output_config", output_config)?;
+        }
+        if let Some(stop_sequences) = &params.stop_sequences {
+            state.serialize_field("stop_sequences", stop_sequences)?;
+        }
+        if let Some(system) = &params.system {
+            state.serialize_field("system", system)?;
+        }
+        if let Some(temperature) = &params.temperature {
+            state.serialize_field("temperature", temperature)?;
+        }
+        if let Some(thinking) = &params.thinking {
+            state.serialize_field("thinking", thinking)?;
+        }
+        if let Some(tool_choice) = &params.tool_choice {
+            state.serialize_field("tool_choice", tool_choice)?;
+        }
+        if let Some(tools) = &params.tools {
+            state.serialize_field("tools", tools)?;
+        }
+        if let Some(top_k) = &params.top_k {
+            state.serialize_field("top_k", top_k)?;
+        }
+        if let Some(top_p) = &params.top_p {
+            state.serialize_field("top_p", top_p)?;
+        }
+        state.end()
+    }
+}
+
+/// A Message Batch returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBatch {
+    /// Unique object identifier.
+    pub id: String,
+
+    /// Object type, always `"message_batch"`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+
+    /// Current processing status for the batch.
+    pub processing_status: MessageBatchProcessingStatus,
+
+    /// Counts of individual requests by processing state.
+    pub request_counts: MessageBatchRequestCounts,
+
+    /// Time at which processing ended, if the batch has ended.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub ended_at: Option<OffsetDateTime>,
+
+    /// Time at which the batch was created.
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+
+    /// Time at which the batch expires if it has not completed.
+    #[serde(with = "time::serde::rfc3339")]
+    pub expires_at: OffsetDateTime,
+
+    /// Time at which cancellation was initiated, if any.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub cancel_initiated_at: Option<OffsetDateTime>,
+
+    /// URL where results may be downloaded once available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub results_url: Option<String>,
+
+    /// Time at which results were archived and became unavailable, if any.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub archived_at: Option<OffsetDateTime>,
+}
+
+/// Processing status for a Message Batch.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageBatchProcessingStatus {
+    /// The batch is actively processing.
+    InProgress,
+
+    /// Cancellation has been requested and is being finalized.
+    Canceling,
+
+    /// The batch has ended and no more requests will be processed.
+    Ended,
+}
+
+/// Counts of individual batch requests by processing state.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBatchRequestCounts {
+    /// Requests still being processed.
+    pub processing: u32,
+
+    /// Requests that completed successfully.
+    pub succeeded: u32,
+
+    /// Requests that returned an error without creating a message.
+    pub errored: u32,
+
+    /// Requests canceled before being sent to the model.
+    pub canceled: u32,
+
+    /// Requests that expired before being sent to the model.
+    pub expired: u32,
+}
+
+/// Parameters for listing Message Batches.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBatchListParams {
+    /// ID of the object to use as a cursor for results after this object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+
+    /// ID of the object to use as a cursor for results before this object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+
+    /// Number of items to return per page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+
+    /// Beta feature headers to include with this list request.
+    #[serde(skip)]
+    pub betas: Option<Vec<String>>,
+}
+
+impl MessageBatchListParams {
+    /// Create empty list parameters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the `after_id` cursor.
+    pub fn with_after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    /// Set the `before_id` cursor.
+    pub fn with_before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    /// Set the number of items to return.
+    pub fn with_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Set beta feature headers for this list request.
+    pub fn with_betas(mut self, betas: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.betas = Some(betas.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Add a single beta feature header for this list request.
+    pub fn with_beta(mut self, beta: impl Into<String>) -> Self {
+        self.betas.get_or_insert_with(Vec::new).push(beta.into());
+        self
+    }
+}
+
+/// A page of Message Batch objects.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBatchListResponse {
+    /// Message Batch objects returned by the API.
+    pub data: Vec<MessageBatch>,
+
+    /// Whether another page is available.
+    pub has_more: bool,
+
+    /// The first object ID in this page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+
+    /// The last object ID in this page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+}
+
+/// A single result line from a Message Batch results JSONL stream.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessageBatchResult {
+    /// Caller-provided ID from the corresponding batch request.
+    pub custom_id: String,
+
+    /// Result for the individual request.
+    pub result: MessageBatchResultVariant,
+}
+
+/// Result for a single request within a Message Batch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum MessageBatchResultVariant {
+    /// The request completed successfully and produced a message.
+    #[serde(rename = "succeeded")]
+    Succeeded {
+        /// Message generated by the model.
+        message: Message,
+    },
+
+    /// The request failed before a message was created.
+    #[serde(rename = "errored")]
+    Errored {
+        /// Standard Anthropic error response for the failed request.
+        error: MessageBatchErrorResponse,
+    },
+
+    /// The request was canceled before being sent to the model.
+    #[serde(rename = "canceled")]
+    Canceled,
+
+    /// The request expired before being sent to the model.
+    #[serde(rename = "expired")]
+    Expired,
+}
+
+/// Standard Anthropic error response embedded in a batch result.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MessageBatchErrorResponse {
+    /// Object type, normally `"error"`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+
+    /// Error details.
+    pub error: MessageBatchError,
+}
+
+impl<'de> Deserialize<'de> for MessageBatchErrorResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            #[serde(rename = "type")]
+            r#type: Option<String>,
+            error: Option<MessageBatchError>,
+            message: Option<String>,
+            param: Option<String>,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        if let Some(error) = helper.error {
+            return Ok(Self {
+                r#type: helper.r#type.unwrap_or_else(|| "error".to_string()),
+                error,
+            });
+        }
+
+        let error_type = helper
+            .r#type
+            .ok_or_else(|| D::Error::missing_field("type"))?;
+        let message = helper
+            .message
+            .ok_or_else(|| D::Error::missing_field("message"))?;
+        Ok(Self {
+            r#type: "error".to_string(),
+            error: MessageBatchError {
+                r#type: error_type,
+                message,
+                param: helper.param,
+            },
+        })
+    }
+}
+
+/// Error details for a failed request within a Message Batch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBatchError {
+    /// Anthropic error type.
+    #[serde(rename = "type")]
+    pub r#type: String,
+
+    /// Human-readable error message.
+    pub message: String,
+
+    /// Request parameter associated with the error, if supplied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
+}
+
+/// Response returned after deleting a Message Batch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeletedMessageBatch {
+    /// Deleted batch ID.
+    pub id: String,
+
+    /// Object type, always `"message_batch_deleted"`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+}
+
+fn is_valid_custom_id(custom_id: &str) -> bool {
+    !custom_id.is_empty()
+        && custom_id.len() <= 64
+        && custom_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{KnownModel, MessageParam, Model, TextBlock, Usage};
+    use serde_json::{json, to_value};
+    use time::macros::datetime;
+
+    fn valid_message_params() -> MessageCreateParams {
+        MessageCreateParams::new(
+            1024,
+            vec![MessageParam::user("Hello, world")],
+            Model::Known(KnownModel::ClaudeOpus48),
+        )
+    }
+
+    fn valid_batch_request(custom_id: &str) -> MessageBatchCreateRequest {
+        MessageBatchCreateRequest::new(custom_id, valid_message_params())
+    }
+
+    #[test]
+    fn batch_create_params_serialize_without_stream_or_betas() {
+        let params = MessageBatchCreateParams::new(vec![valid_batch_request("my-first-request")])
+            .with_beta("output-300k-2026-03-24");
+
+        let json = to_value(&params).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "requests": [{
+                    "custom_id": "my-first-request",
+                    "params": {
+                        "max_tokens": 1024,
+                        "messages": [{
+                            "role": "user",
+                            "content": "Hello, world"
+                        }],
+                        "model": "claude-opus-4-8"
+                    }
+                }]
+            })
+        );
+        assert!(json["requests"][0]["params"].get("stream").is_none());
+        assert!(json.get("betas").is_none());
+    }
+
+    #[test]
+    fn batch_create_params_validate_success() {
+        let params = MessageBatchCreateParams::new(vec![valid_batch_request("request_1")]);
+        assert!(params.validate().is_ok());
+    }
+
+    #[test]
+    fn batch_create_params_reject_empty_requests() {
+        let params = MessageBatchCreateParams::new(Vec::new());
+        assert!(params.validate().unwrap_err().is_validation());
+    }
+
+    #[test]
+    fn batch_create_params_reject_too_many_requests() {
+        let params = MessageBatchCreateParams::new(vec![
+            valid_batch_request("request_1");
+            MAX_MESSAGE_BATCH_REQUESTS + 1
+        ]);
+        assert!(params.validate().unwrap_err().is_validation());
+    }
+
+    #[test]
+    fn batch_create_params_reject_invalid_custom_id() {
+        let params = MessageBatchCreateParams::new(vec![valid_batch_request("bad id")]);
+        let err = params.validate().unwrap_err();
+        assert!(err.is_validation());
+        assert!(err.to_string().contains("custom_id"));
+    }
+
+    #[test]
+    fn batch_create_params_reject_duplicate_custom_id() {
+        let params = MessageBatchCreateParams::new(vec![
+            valid_batch_request("same-id"),
+            valid_batch_request("same-id"),
+        ]);
+        let err = params.validate().unwrap_err();
+        assert!(err.is_validation());
+        assert!(err.to_string().contains("Duplicate custom_id"));
+    }
+
+    #[test]
+    fn batch_create_params_reject_streaming_request() {
+        let mut request = valid_batch_request("streaming");
+        request.params.stream = true;
+        let params = MessageBatchCreateParams::new(vec![request]);
+        let err = params.validate().unwrap_err();
+        assert!(err.is_validation());
+        assert!(err.to_string().contains("stream"));
+    }
+
+    #[test]
+    fn batch_create_params_reject_zero_max_tokens() {
+        let mut request = valid_batch_request("zero-tokens");
+        request.params.max_tokens = 0;
+        let params = MessageBatchCreateParams::new(vec![request]);
+        let err = params.validate().unwrap_err();
+        assert!(err.is_validation());
+        assert!(err.to_string().contains("max_tokens"));
+    }
+
+    #[test]
+    fn message_batch_deserialization() {
+        let json = json!({
+            "id": "msgbatch_01HkcTjaV5uDC8jWR4ZsDV8d",
+            "type": "message_batch",
+            "processing_status": "in_progress",
+            "request_counts": {
+                "processing": 2,
+                "succeeded": 0,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0
+            },
+            "ended_at": null,
+            "created_at": "2024-09-24T18:37:24.100435Z",
+            "expires_at": "2024-09-25T18:37:24.100435Z",
+            "cancel_initiated_at": null,
+            "results_url": null,
+            "archived_at": null
+        });
+
+        let batch: MessageBatch = serde_json::from_value(json).unwrap();
+        assert_eq!(batch.id, "msgbatch_01HkcTjaV5uDC8jWR4ZsDV8d");
+        assert_eq!(
+            batch.processing_status,
+            MessageBatchProcessingStatus::InProgress
+        );
+        assert_eq!(batch.request_counts.processing, 2);
+        assert!(batch.ended_at.is_none());
+    }
+
+    #[test]
+    fn message_batch_list_response_deserialization() {
+        let batch = MessageBatch {
+            id: "msgbatch_123".to_string(),
+            r#type: "message_batch".to_string(),
+            processing_status: MessageBatchProcessingStatus::Ended,
+            request_counts: MessageBatchRequestCounts {
+                processing: 0,
+                succeeded: 1,
+                errored: 0,
+                canceled: 0,
+                expired: 0,
+            },
+            ended_at: Some(datetime!(2024-09-24 19:37:24 UTC)),
+            created_at: datetime!(2024-09-24 18:37:24 UTC),
+            expires_at: datetime!(2024-09-25 18:37:24 UTC),
+            cancel_initiated_at: None,
+            results_url: Some("https://api.anthropic.com/result".to_string()),
+            archived_at: None,
+        };
+        let response = MessageBatchListResponse {
+            data: vec![batch.clone()],
+            has_more: false,
+            first_id: Some(batch.id.clone()),
+            last_id: Some(batch.id.clone()),
+        };
+
+        let json = to_value(&response).unwrap();
+        let decoded: MessageBatchListResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.data[0], batch);
+        assert!(!decoded.has_more);
+    }
+
+    #[test]
+    fn batch_result_succeeded_deserialization() {
+        let json = json!({
+            "custom_id": "my-first-request",
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-opus-4-8",
+                    "content": [{"type": "text", "text": "Hello"}],
+                    "stop_reason": "end_turn",
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 10, "output_tokens": 2}
+                }
+            }
+        });
+
+        let result: MessageBatchResult = serde_json::from_value(json).unwrap();
+        match result.result {
+            MessageBatchResultVariant::Succeeded { message } => {
+                assert_eq!(message.id, "msg_123");
+            }
+            _ => panic!("expected succeeded result"),
+        }
+    }
+
+    #[test]
+    fn batch_result_errored_deserializes_standard_error_shape() {
+        let json = json!({
+            "custom_id": "bad-request",
+            "result": {
+                "type": "errored",
+                "error": {
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "max_tokens must be at least 1"
+                    }
+                }
+            }
+        });
+
+        let result: MessageBatchResult = serde_json::from_value(json).unwrap();
+        match result.result {
+            MessageBatchResultVariant::Errored { error } => {
+                assert_eq!(error.r#type, "error");
+                assert_eq!(error.error.r#type, "invalid_request_error");
+            }
+            _ => panic!("expected errored result"),
+        }
+    }
+
+    #[test]
+    fn batch_result_errored_deserializes_direct_error_shape() {
+        let json = json!({
+            "custom_id": "bad-request",
+            "result": {
+                "type": "errored",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "max_tokens must be at least 1"
+                }
+            }
+        });
+
+        let result: MessageBatchResult = serde_json::from_value(json).unwrap();
+        match result.result {
+            MessageBatchResultVariant::Errored { error } => {
+                assert_eq!(error.r#type, "error");
+                assert_eq!(error.error.r#type, "invalid_request_error");
+            }
+            _ => panic!("expected errored result"),
+        }
+    }
+
+    #[test]
+    fn batch_result_canceled_and_expired_deserialization() {
+        let canceled: MessageBatchResult = serde_json::from_value(json!({
+            "custom_id": "canceled-request",
+            "result": {"type": "canceled"}
+        }))
+        .unwrap();
+        assert!(matches!(
+            canceled.result,
+            MessageBatchResultVariant::Canceled
+        ));
+
+        let expired: MessageBatchResult = serde_json::from_value(json!({
+            "custom_id": "expired-request",
+            "result": {"type": "expired"}
+        }))
+        .unwrap();
+        assert!(matches!(expired.result, MessageBatchResultVariant::Expired));
+    }
+
+    #[test]
+    fn deleted_message_batch_deserialization() {
+        let deleted: DeletedMessageBatch = serde_json::from_value(json!({
+            "id": "msgbatch_123",
+            "type": "message_batch_deleted"
+        }))
+        .unwrap();
+        assert_eq!(deleted.id, "msgbatch_123");
+        assert_eq!(deleted.r#type, "message_batch_deleted");
+    }
+
+    #[test]
+    fn message_batch_result_round_trip_succeeded() {
+        let message = Message::new(
+            "msg_123".to_string(),
+            vec![TextBlock::new("Hello").into()],
+            Model::Known(KnownModel::ClaudeOpus48),
+            Usage::new(1, 1),
+        );
+        let result = MessageBatchResult {
+            custom_id: "request-1".to_string(),
+            result: MessageBatchResultVariant::Succeeded { message },
+        };
+
+        let json = to_value(&result).unwrap();
+        assert_eq!(json["result"]["type"], "succeeded");
+        let decoded: MessageBatchResult = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.custom_id, "request-1");
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -18,6 +18,7 @@ mod document_block;
 mod image_block;
 mod input_json_delta;
 mod message;
+mod message_batch;
 mod message_count_tokens_params;
 mod message_create_params;
 mod message_create_template;
@@ -88,6 +89,12 @@ pub use document_block::{DocumentBlock, DocumentSource};
 pub use image_block::{ImageBlock, ImageSource};
 pub use input_json_delta::InputJsonDelta;
 pub use message::Message;
+pub use message_batch::{
+    DeletedMessageBatch, MessageBatch, MessageBatchCreateParams, MessageBatchCreateRequest,
+    MessageBatchError, MessageBatchErrorResponse, MessageBatchListParams, MessageBatchListResponse,
+    MessageBatchProcessingStatus, MessageBatchRequestCounts, MessageBatchResult,
+    MessageBatchResultVariant,
+};
 pub use message_count_tokens_params::MessageCountTokensParams;
 pub use message_create_params::MessageCreateParams;
 pub use message_create_template::MessageCreateTemplate;


### PR DESCRIPTION
Add support for the Anthropic Message Batches API, enabling
asynchronous bulk processing of message requests.

- Introduce message_batch types: MessageBatch, MessageBatchCreateParams,
  MessageBatchListParams/Response, MessageBatchResult variants, request
  counts, processing status, and error/deleted-batch representations.
- Extend Client with batch create/retrieve/list/cancel/delete and a
  streaming JSONL results reader that parses results line-by-line with
  bounded line buffering and structured error mapping.
- Re-export the new types from src/types/mod.rs.
- Add examples/batch.rs demonstrating end-to-end batch usage.

Co-authored-by: AI
