### PR TITLE
feat(types): add thinking display control to ThinkingConfig

### DIFF
--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -42,7 +42,9 @@ use claudius::chat::{
     ChatAgent, ChatArgs, ChatCommand, ChatConfig, ChatSession, PlainTextRenderer, help_text,
     parse_command,
 };
-use claudius::{Anthropic, Effort, Model, StopReason, SystemPrompt, ThinkingConfig};
+use claudius::{
+    Anthropic, Effort, Model, StopReason, SystemPrompt, ThinkingConfig, ThinkingDisplay,
+};
 use claudius::{OperatorLine, Renderer, StreamContext};
 
 struct ChatTerminal {
@@ -478,7 +480,7 @@ fn print_stop_sequences(stop_sequences: &[String]) {
 
 fn describe_thinking(stats: &claudius::chat::SessionStats) -> String {
     match stats.thinking_config {
-        Some(ThinkingConfig::Adaptive) => {
+        Some(ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. }) => {
             let effort = stats
                 .effort
                 .map(|e| match e {
@@ -487,12 +489,29 @@ fn describe_thinking(stats: &claudius::chat::SessionStats) -> String {
                     Effort::High => "high",
                 })
                 .unwrap_or("default");
-            format!("adaptive (effort: {effort})")
+            format!(
+                "adaptive (effort: {effort}{})",
+                describe_display(stats.thinking_config.and_then(|config| config.display()))
+            )
         }
-        Some(ThinkingConfig::Enabled { budget_tokens }) => {
-            format!("enabled ({budget_tokens} tokens)")
+        Some(
+            ThinkingConfig::Enabled { budget_tokens }
+            | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. },
+        ) => {
+            format!(
+                "enabled ({budget_tokens} tokens{})",
+                describe_display(stats.thinking_config.and_then(|config| config.display()))
+            )
         }
         Some(ThinkingConfig::Disabled) | None => "disabled".to_string(),
+    }
+}
+
+fn describe_display(display: Option<ThinkingDisplay>) -> &'static str {
+    match display {
+        Some(ThinkingDisplay::Summarized) => ", display: summarized",
+        Some(ThinkingDisplay::Omitted) => ", display: omitted",
+        None => "",
     }
 }
 

--- a/src/bin/median-text.rs
+++ b/src/bin/median-text.rs
@@ -39,7 +39,7 @@ Output the corrected/unified document and only the corrected/unified document.
         output_format: None,
         output_config: None,
         stop_sequences: None,
-        thinking: Some(ThinkingConfig::enabled(1024)),
+        thinking: Some(ThinkingConfig::enabled_summarized(1024)),
         tools: None,
         temperature: None,
         tool_choice: None,

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -142,12 +142,12 @@ impl TryFrom<ChatArgs> for MessageCreateTemplate {
 
         if let Some(ref effort_str) = args.effort {
             let effort = parse_effort(effort_str)?;
-            template.thinking = Some(ThinkingConfig::Adaptive);
+            template.thinking = Some(ThinkingConfig::adaptive_summarized());
             template.output_config = Some(OutputConfig::new().with_effort(effort));
         }
 
         if let Some(thinking) = args.thinking {
-            template.thinking = Some(ThinkingConfig::enabled(thinking));
+            template.thinking = Some(ThinkingConfig::enabled_summarized(thinking));
         }
 
         Ok(template)
@@ -246,7 +246,7 @@ impl ChatConfig {
     /// `None` disables thinking, `Some(budget)` enables with the given token budget.
     /// Clears any adaptive effort setting to avoid conflicting modes.
     pub fn with_thinking_budget(mut self, budget: Option<u32>) -> Self {
-        self.template.thinking = budget.map(ThinkingConfig::enabled);
+        self.template.thinking = budget.map(ThinkingConfig::enabled_summarized);
         self.template.output_config = None;
         self.effort = None;
         self
@@ -254,7 +254,7 @@ impl ChatConfig {
 
     /// Sets adaptive thinking with an optional effort level.
     pub fn with_thinking_adaptive(mut self, effort: Option<Effort>) -> Self {
-        self.template.thinking = Some(ThinkingConfig::Adaptive);
+        self.template.thinking = Some(ThinkingConfig::adaptive_summarized());
         self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
         self.effort = effort;
         self
@@ -264,6 +264,7 @@ impl ChatConfig {
     pub fn with_effort(mut self, effort: Option<Effort>) -> Self {
         self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
         self.effort = effort;
+        self.ensure_adaptive_thinking_has_display();
         self
     }
 
@@ -323,7 +324,10 @@ impl ChatConfig {
     /// Returns the configured thinking budget, if enabled.
     pub fn thinking_budget(&self) -> Option<u32> {
         match self.template.thinking {
-            Some(ThinkingConfig::Enabled { budget_tokens }) => Some(budget_tokens),
+            Some(
+                ThinkingConfig::Enabled { budget_tokens }
+                | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. },
+            ) => Some(budget_tokens),
             _ => None,
         }
     }
@@ -339,12 +343,13 @@ impl ChatConfig {
     /// Returns the resolved thinking mode.
     pub fn thinking_mode(&self) -> ThinkingMode {
         match self.template.thinking {
-            Some(ThinkingConfig::Adaptive) => {
+            Some(ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. }) => {
                 ThinkingMode::Adaptive(self.effort.unwrap_or(Effort::Medium))
             }
-            Some(ThinkingConfig::Enabled { budget_tokens }) => {
-                ThinkingMode::Budgeted(budget_tokens)
-            }
+            Some(
+                ThinkingConfig::Enabled { budget_tokens }
+                | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. },
+            ) => ThinkingMode::Budgeted(budget_tokens),
             Some(ThinkingConfig::Disabled) | None => ThinkingMode::Disabled,
         }
     }
@@ -393,14 +398,14 @@ impl ChatConfig {
     /// Sets the thinking budget.
     /// Clears any adaptive effort setting to avoid conflicting modes.
     pub fn set_thinking_budget(&mut self, budget: Option<u32>) {
-        self.template.thinking = budget.map(ThinkingConfig::enabled);
+        self.template.thinking = budget.map(ThinkingConfig::enabled_summarized);
         self.template.output_config = None;
         self.effort = None;
     }
 
     /// Sets adaptive thinking with an optional effort level.
     pub fn set_thinking_adaptive(&mut self, effort: Option<Effort>) {
-        self.template.thinking = Some(ThinkingConfig::Adaptive);
+        self.template.thinking = Some(ThinkingConfig::adaptive_summarized());
         self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
         self.effort = effort;
     }
@@ -409,6 +414,7 @@ impl ChatConfig {
     pub fn set_effort(&mut self, effort: Option<Effort>) {
         self.template.output_config = effort.map(|e| OutputConfig::new().with_effort(e));
         self.effort = effort;
+        self.ensure_adaptive_thinking_has_display();
     }
 
     /// Sets the session spend limit in dollars, using the configured model's token rates.
@@ -431,6 +437,15 @@ impl ChatConfig {
                 // Fall back to Sonnet 4.5 rates for custom/unknown models.
                 Budget::from_dollars_with_model(dollars, KnownModel::ClaudeSonnet45)
             }
+        }
+    }
+
+    fn ensure_adaptive_thinking_has_display(&mut self) {
+        if matches!(
+            self.template.thinking,
+            Some(ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. })
+        ) {
+            self.template.thinking = Some(ThinkingConfig::adaptive_summarized());
         }
     }
 }
@@ -529,6 +544,22 @@ mod tests {
     }
 
     #[test]
+    fn config_from_args_effort_uses_adaptive_display() {
+        let args = ChatArgs {
+            effort: Some("high".to_string()),
+            ..Default::default()
+        };
+
+        let config = ChatConfig::try_from(args).unwrap();
+
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
+        assert_eq!(config.effort(), Some(Effort::High));
+    }
+
+    #[test]
     fn config_from_args_invalid_temperature() {
         let args = ChatArgs {
             temperature: Some("not-a-number".to_string()),
@@ -580,8 +611,9 @@ mod tests {
         assert_eq!(config.thinking_budget(), Some(2048));
         assert_eq!(
             config.thinking_config(),
-            Some(ThinkingConfig::Enabled {
-                budget_tokens: 2048
+            Some(ThinkingConfig::EnabledWithDisplay {
+                budget_tokens: 2048,
+                display: crate::types::ThinkingDisplay::Summarized
             })
         );
         assert_eq!(config.effort(), None);
@@ -600,7 +632,10 @@ mod tests {
     fn config_adaptive_thinking() {
         let config = ChatConfig::new().with_thinking_adaptive(Some(Effort::High));
 
-        assert_eq!(config.thinking_config(), Some(ThinkingConfig::Adaptive));
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
         assert_eq!(config.effort(), Some(Effort::High));
         assert_eq!(config.thinking_budget(), None);
         assert!(config.output_config().is_some());
@@ -623,9 +658,37 @@ mod tests {
         assert_eq!(config.thinking_budget(), Some(4096));
 
         config.set_thinking_adaptive(Some(Effort::Low));
-        assert_eq!(config.thinking_config(), Some(ThinkingConfig::Adaptive));
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
         assert_eq!(config.effort(), Some(Effort::Low));
         assert_eq!(config.thinking_budget(), None);
+    }
+
+    #[test]
+    fn effort_setters_normalize_adaptive_to_display_mode() {
+        let config = ChatConfig {
+            template: MessageCreateTemplate::new().with_thinking(ThinkingConfig::Adaptive),
+            ..ChatConfig::new()
+        }
+        .with_effort(Some(Effort::Medium));
+
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
+
+        let mut config = ChatConfig {
+            template: MessageCreateTemplate::new().with_thinking(ThinkingConfig::Adaptive),
+            ..ChatConfig::new()
+        };
+        config.set_effort(Some(Effort::High));
+
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
     }
 
     #[test]

--- a/src/types/message_create_params.rs
+++ b/src/types/message_create_params.rs
@@ -527,7 +527,8 @@ impl MessageCreateParams {
         // Validate thinking config with security checks
         if let Some(ref thinking) = self.thinking {
             match thinking {
-                ThinkingConfig::Enabled { budget_tokens } => {
+                ThinkingConfig::Enabled { budget_tokens }
+                | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. } => {
                     if *budget_tokens < 1024 {
                         return Err(crate::Error::validation(
                             format!(
@@ -559,7 +560,7 @@ impl MessageCreateParams {
                 ThinkingConfig::Disabled => {
                     // No validation needed for disabled state
                 }
-                ThinkingConfig::Adaptive => {
+                ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. } => {
                     // No validation needed for adaptive thinking
                 }
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -123,7 +123,7 @@ pub use text_block::TextBlock;
 pub use text_citation::TextCitation;
 pub use text_delta::TextDelta;
 pub use thinking_block::ThinkingBlock;
-pub use thinking_config::ThinkingConfig;
+pub use thinking_config::{ThinkingConfig, ThinkingDisplay};
 pub use thinking_delta::ThinkingDelta;
 pub use tool_bash_20241022::ToolBash20241022;
 pub use tool_bash_20250124::ToolBash20250124;

--- a/src/types/thinking_config.rs
+++ b/src/types/thinking_config.rs
@@ -1,13 +1,24 @@
-use serde::{Deserialize, Serialize};
+use serde::de;
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Controls how extended thinking content is returned in API responses.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingDisplay {
+    /// Return summarized thinking text in `thinking` blocks.
+    Summarized,
+    /// Return `thinking` blocks with empty thinking text and only the signature.
+    Omitted,
+}
 
 /// Configuration for enabling Claude's extended thinking capabilities.
 ///
-/// This can be either enabled (with a token budget) or disabled.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type")]
+/// This can be disabled, adaptive, or enabled with a token budget. Display-aware
+/// variants add the API's `display` field without changing the JSON `type`.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ThinkingConfig {
     /// Disabled thinking configuration.
-    #[serde(rename = "disabled")]
     Disabled,
 
     /// Adaptive thinking configuration.
@@ -15,11 +26,15 @@ pub enum ThinkingConfig {
     /// When enabled, Claude automatically determines the appropriate amount of thinking
     /// based on the task complexity. Use with the effort parameter in `OutputConfig`
     /// to control thinking depth.
-    #[serde(rename = "adaptive")]
     Adaptive,
 
+    /// Adaptive thinking configuration with explicit response display behavior.
+    AdaptiveWithDisplay {
+        /// Controls how thinking content is returned.
+        display: ThinkingDisplay,
+    },
+
     /// Enabled thinking configuration with a token budget.
-    #[serde(rename = "enabled")]
     Enabled {
         /// Determines how many tokens Claude can use for its internal reasoning process.
         ///
@@ -27,20 +42,31 @@ pub enum ThinkingConfig {
         /// response quality.
         ///
         /// Must be ≥1024 and less than `max_tokens`.
-        #[serde(rename = "budget_tokens")]
         budget_tokens: u32,
+    },
+
+    /// Enabled thinking configuration with a token budget and explicit response display behavior.
+    EnabledWithDisplay {
+        /// Determines how many tokens Claude can use for its internal reasoning process.
+        ///
+        /// Must be ≥1024 and less than `max_tokens`.
+        budget_tokens: u32,
+        /// Controls how thinking content is returned.
+        display: ThinkingDisplay,
     },
 }
 
 impl ThinkingConfig {
     /// Returns the number of budget tokens configured for thinking.
     ///
-    /// Returns 0 if thinking is disabled.
+    /// Returns 0 if thinking is disabled or adaptive.
     pub fn num_tokens(&self) -> u32 {
         match self {
-            ThinkingConfig::Disabled => 0,
-            ThinkingConfig::Adaptive => 0,
-            ThinkingConfig::Enabled { budget_tokens } => *budget_tokens,
+            ThinkingConfig::Disabled
+            | ThinkingConfig::Adaptive
+            | ThinkingConfig::AdaptiveWithDisplay { .. } => 0,
+            ThinkingConfig::Enabled { budget_tokens }
+            | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. } => *budget_tokens,
         }
     }
 
@@ -51,6 +77,20 @@ impl ThinkingConfig {
         Self::Enabled { budget_tokens }
     }
 
+    /// Create a new enabled thinking configuration that requests summarized thinking.
+    ///
+    /// Budget tokens must be ≥1024.
+    pub fn enabled_summarized(budget_tokens: u32) -> Self {
+        Self::enabled(budget_tokens).with_display(ThinkingDisplay::Summarized)
+    }
+
+    /// Create a new enabled thinking configuration that omits thinking text.
+    ///
+    /// Budget tokens must be ≥1024.
+    pub fn enabled_omitted(budget_tokens: u32) -> Self {
+        Self::enabled(budget_tokens).with_display(ThinkingDisplay::Omitted)
+    }
+
     /// Create a new disabled thinking configuration.
     pub fn disabled() -> Self {
         Self::Disabled
@@ -59,6 +99,129 @@ impl ThinkingConfig {
     /// Create a new adaptive thinking configuration.
     pub fn adaptive() -> Self {
         Self::Adaptive
+    }
+
+    /// Create a new adaptive thinking configuration that requests summarized thinking.
+    pub fn adaptive_summarized() -> Self {
+        Self::adaptive().with_display(ThinkingDisplay::Summarized)
+    }
+
+    /// Create a new adaptive thinking configuration that omits thinking text.
+    pub fn adaptive_omitted() -> Self {
+        Self::adaptive().with_display(ThinkingDisplay::Omitted)
+    }
+
+    /// Set how thinking content should be returned.
+    ///
+    /// `display` is only valid for enabled or adaptive thinking. Calling this on
+    /// disabled thinking leaves it unchanged.
+    pub fn with_display(self, display: ThinkingDisplay) -> Self {
+        match self {
+            ThinkingConfig::Disabled => ThinkingConfig::Disabled,
+            ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. } => {
+                ThinkingConfig::AdaptiveWithDisplay { display }
+            }
+            ThinkingConfig::Enabled { budget_tokens }
+            | ThinkingConfig::EnabledWithDisplay { budget_tokens, .. } => {
+                ThinkingConfig::EnabledWithDisplay {
+                    budget_tokens,
+                    display,
+                }
+            }
+        }
+    }
+
+    /// Returns the configured thinking display mode, if any.
+    pub fn display(&self) -> Option<ThinkingDisplay> {
+        match self {
+            ThinkingConfig::AdaptiveWithDisplay { display }
+            | ThinkingConfig::EnabledWithDisplay { display, .. } => Some(*display),
+            ThinkingConfig::Disabled
+            | ThinkingConfig::Adaptive
+            | ThinkingConfig::Enabled { .. } => None,
+        }
+    }
+}
+
+impl Serialize for ThinkingConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            ThinkingConfig::Disabled => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("type", "disabled")?;
+                map.end()
+            }
+            ThinkingConfig::Adaptive => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("type", "adaptive")?;
+                map.end()
+            }
+            ThinkingConfig::AdaptiveWithDisplay { display } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("type", "adaptive")?;
+                map.serialize_entry("display", display)?;
+                map.end()
+            }
+            ThinkingConfig::Enabled { budget_tokens } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("type", "enabled")?;
+                map.serialize_entry("budget_tokens", budget_tokens)?;
+                map.end()
+            }
+            ThinkingConfig::EnabledWithDisplay {
+                budget_tokens,
+                display,
+            } => {
+                let mut map = serializer.serialize_map(Some(3))?;
+                map.serialize_entry("type", "enabled")?;
+                map.serialize_entry("budget_tokens", budget_tokens)?;
+                map.serialize_entry("display", display)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ThinkingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawThinkingConfig {
+            #[serde(rename = "type")]
+            kind: String,
+            budget_tokens: Option<u32>,
+            display: Option<ThinkingDisplay>,
+        }
+
+        let raw = RawThinkingConfig::deserialize(deserializer)?;
+        match raw.kind.as_str() {
+            "disabled" => Ok(ThinkingConfig::Disabled),
+            "adaptive" => Ok(match raw.display {
+                Some(display) => ThinkingConfig::AdaptiveWithDisplay { display },
+                None => ThinkingConfig::Adaptive,
+            }),
+            "enabled" => {
+                let budget_tokens = raw
+                    .budget_tokens
+                    .ok_or_else(|| de::Error::missing_field("budget_tokens"))?;
+                Ok(match raw.display {
+                    Some(display) => ThinkingConfig::EnabledWithDisplay {
+                        budget_tokens,
+                        display,
+                    },
+                    None => ThinkingConfig::Enabled { budget_tokens },
+                })
+            }
+            other => Err(de::Error::unknown_variant(
+                other,
+                &["disabled", "adaptive", "enabled"],
+            )),
+        }
     }
 }
 
@@ -152,6 +315,69 @@ mod tests {
         match config {
             ThinkingConfig::Adaptive => {}
             _ => panic!("Expected Adaptive variant"),
+        }
+    }
+
+    #[test]
+    fn thinking_display_serialization() {
+        assert_eq!(
+            to_value(ThinkingDisplay::Summarized).unwrap(),
+            json!("summarized")
+        );
+        assert_eq!(
+            to_value(ThinkingDisplay::Omitted).unwrap(),
+            json!("omitted")
+        );
+    }
+
+    #[test]
+    fn thinking_config_enabled_summarized_serialization() {
+        let config = ThinkingConfig::enabled_summarized(2048);
+        let json = to_value(config).unwrap();
+
+        assert_eq!(
+            json,
+            json!({
+                "type": "enabled",
+                "budget_tokens": 2048,
+                "display": "summarized"
+            })
+        );
+    }
+
+    #[test]
+    fn thinking_config_adaptive_summarized_serialization() {
+        let config = ThinkingConfig::adaptive_summarized();
+        let json = to_value(config).unwrap();
+
+        assert_eq!(
+            json,
+            json!({
+                "type": "adaptive",
+                "display": "summarized"
+            })
+        );
+    }
+
+    #[test]
+    fn thinking_config_display_deserialization() {
+        let json = json!({
+            "type": "enabled",
+            "budget_tokens": 2048,
+            "display": "omitted"
+        });
+
+        let config: ThinkingConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.display(), Some(ThinkingDisplay::Omitted));
+        match config {
+            ThinkingConfig::EnabledWithDisplay {
+                budget_tokens,
+                display,
+            } => {
+                assert_eq!(budget_tokens, 2048);
+                assert_eq!(display, ThinkingDisplay::Omitted);
+            }
+            _ => panic!("Expected EnabledWithDisplay variant"),
         }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -107,14 +107,12 @@ mod tests {
         let mut params = MessageCreateParams::simple("test", KnownModel::ClaudeHaiku45);
 
         // Test thinking config with insufficient budget
-        params = params.with_thinking(ThinkingConfig::Enabled { budget_tokens: 500 });
+        params = params.with_thinking(ThinkingConfig::enabled(500));
         assert!(params.validate().is_err(), "Should reject budget < 1024");
 
         // Test thinking config exceeding max_tokens
         params.max_tokens = 1000;
-        params = params.with_thinking(ThinkingConfig::Enabled {
-            budget_tokens: 1500,
-        });
+        params = params.with_thinking(ThinkingConfig::enabled(1500));
         assert!(
             params.validate().is_err(),
             "Should reject budget > max_tokens"
@@ -122,9 +120,7 @@ mod tests {
 
         // Test valid thinking config
         params.max_tokens = 2000;
-        params = params.with_thinking(ThinkingConfig::Enabled {
-            budget_tokens: 1024,
-        });
+        params = params.with_thinking(ThinkingConfig::enabled(1024));
         assert!(
             params.validate().is_ok(),
             "Should accept valid thinking config"


### PR DESCRIPTION
Introduce a ThinkingDisplay enum (Summarized, Omitted) and two
display-aware ThinkingConfig variants, AdaptiveWithDisplay and
EnabledWithDisplay, so callers can request how extended thinking
content is returned via the API's display field.

The display field is additive: it does not change the JSON type
discriminant, so custom Serialize/Deserialize impls emit and parse
the existing disabled/adaptive/enabled type values plus an optional
display field. This keeps wire compatibility with configs that omit
display while supporting the richer variants.

Add ergonomic constructors (enabled_summarized, enabled_omitted,
adaptive_summarized, adaptive_omitted), a with_display builder, and a
display accessor. The chat config now normalizes adaptive thinking to
a display-aware mode when effort is set, and surfaces the display mode
in claudius-chat status output.

Co-authored-by: AI
