### PR TITLE
feat: support summarized thinking streams and new effort levels

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3095,6 +3095,8 @@ async fn stream_message_with_renderer(
     let (mut acc_stream, rx) = AccumulatingStream::new_with_message(stream, fallback_message);
     let mut active_tool_uses = HashSet::new();
     let mut active_tool_results = HashSet::new();
+    let mut active_thinking_blocks = HashSet::new();
+    let mut rendered_thinking_blocks = HashSet::new();
 
     while let Some(event) = acc_stream.next().await {
         if renderer.should_interrupt() {
@@ -3130,10 +3132,15 @@ async fn stream_message_with_renderer(
                         ContentBlock::Text(text_block) if !text_block.text.is_empty() => {
                             renderer.print_text(context, &text_block.text);
                         }
-                        ContentBlock::Thinking(thinking_block)
-                            if show_thinking && !thinking_block.thinking.is_empty() =>
-                        {
-                            renderer.print_thinking(context, &thinking_block.thinking);
+                        block if block.is_thinking() => {
+                            let thinking_block = block
+                                .as_thinking()
+                                .expect("is_thinking blocks must expose thinking");
+                            active_thinking_blocks.insert(start_event.index);
+                            if show_thinking && !thinking_block.thinking.is_empty() {
+                                rendered_thinking_blocks.insert(start_event.index);
+                                renderer.print_thinking(context, &thinking_block.thinking);
+                            }
                         }
                         _ => {}
                     }
@@ -3145,14 +3152,20 @@ async fn stream_message_with_renderer(
                         }
                     }
                     ContentBlockDelta::TextDelta(text_delta) => {
-                        if active_tool_results.contains(&delta_event.index) {
+                        if active_thinking_blocks.contains(&delta_event.index) {
+                            if show_thinking && !text_delta.text.is_empty() {
+                                rendered_thinking_blocks.insert(delta_event.index);
+                                renderer.print_thinking(context, &text_delta.text);
+                            }
+                        } else if active_tool_results.contains(&delta_event.index) {
                             renderer.print_tool_result_text(context, &text_delta.text);
                         } else {
                             renderer.print_text(context, &text_delta.text);
                         }
                     }
                     ContentBlockDelta::ThinkingDelta(thinking_delta) => {
-                        if show_thinking {
+                        if show_thinking && !thinking_delta.thinking.is_empty() {
+                            rendered_thinking_blocks.insert(delta_event.index);
                             renderer.print_thinking(context, &thinking_delta.thinking);
                         }
                     }
@@ -3166,6 +3179,7 @@ async fn stream_message_with_renderer(
                     if active_tool_results.remove(&stop_event.index) {
                         renderer.finish_tool_result(context);
                     }
+                    active_thinking_blocks.remove(&stop_event.index);
                 }
                 MessageStreamEvent::MessageStop(_) => {}
             },
@@ -3176,9 +3190,18 @@ async fn stream_message_with_renderer(
         }
     }
 
-    renderer.finish_response(context);
     match rx.await {
-        Ok(Ok(resp)) => Ok(resp),
+        Ok(Ok(resp)) => {
+            render_unstreamed_thinking_blocks(
+                renderer,
+                context,
+                show_thinking,
+                &resp,
+                &rendered_thinking_blocks,
+            );
+            renderer.finish_response(context);
+            Ok(resp)
+        }
         Ok(Err(err)) => {
             renderer.print_error(context, &err.to_string());
             Err(err)
@@ -3191,14 +3214,73 @@ async fn stream_message_with_renderer(
     }
 }
 
+fn render_unstreamed_thinking_blocks(
+    renderer: &mut dyn Renderer,
+    context: &dyn StreamContext,
+    show_thinking: bool,
+    message: &Message,
+    rendered_thinking_blocks: &HashSet<usize>,
+) {
+    if !show_thinking {
+        return;
+    }
+
+    for (index, block) in message.content.iter().enumerate() {
+        let Some(thinking_block) = block.as_thinking() else {
+            continue;
+        };
+        if rendered_thinking_blocks.contains(&index) || thinking_block.thinking.is_empty() {
+            continue;
+        }
+        renderer.print_thinking(context, &thinking_block.thinking);
+    }
+}
+
 /////////////////////////////////////////////// tests //////////////////////////////////////////////
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Usage;
+    use crate::{TextBlock, ThinkingBlock, Usage};
     use std::sync::atomic::Ordering;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Default)]
+    struct CapturingRenderer {
+        thinking: Vec<String>,
+    }
+
+    impl Renderer for CapturingRenderer {
+        fn print_text(&mut self, _context: &dyn StreamContext, _text: &str) {}
+
+        fn print_thinking(&mut self, _context: &dyn StreamContext, text: &str) {
+            self.thinking.push(text.to_string());
+        }
+
+        fn print_error(&mut self, _context: &dyn StreamContext, _error: &str) {}
+
+        fn print_info(&mut self, _context: &dyn StreamContext, _info: &str) {}
+
+        fn start_tool_use(&mut self, _context: &dyn StreamContext, _name: &str, _id: &str) {}
+
+        fn print_tool_input(&mut self, _context: &dyn StreamContext, _partial_json: &str) {}
+
+        fn finish_tool_use(&mut self, _context: &dyn StreamContext) {}
+
+        fn start_tool_result(
+            &mut self,
+            _context: &dyn StreamContext,
+            _tool_use_id: &str,
+            _is_error: bool,
+        ) {
+        }
+
+        fn print_tool_result_text(&mut self, _context: &dyn StreamContext, _text: &str) {}
+
+        fn finish_tool_result(&mut self, _context: &dyn StreamContext) {}
+
+        fn finish_response(&mut self, _context: &dyn StreamContext) {}
+    }
 
     fn make_temp_dir(prefix: &str) -> std::path::PathBuf {
         let mut dir = std::env::temp_dir();
@@ -3213,6 +3295,39 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn render_unstreamed_thinking_blocks_prints_missing_summaries() {
+        let message = Message::new(
+            "msg".to_string(),
+            vec![
+                ContentBlock::Thinking(ThinkingBlock::new("summary", "sig")),
+                ContentBlock::Text(TextBlock::new("answer")),
+            ],
+            KnownModel::ClaudeOpus48.into(),
+            Usage::new(10, 20),
+        );
+        let mut renderer = CapturingRenderer::default();
+
+        render_unstreamed_thinking_blocks(&mut renderer, &(), true, &message, &HashSet::new());
+
+        assert_eq!(renderer.thinking, vec!["summary"]);
+    }
+
+    #[test]
+    fn render_unstreamed_thinking_blocks_skips_already_rendered_summaries() {
+        let message = Message::new(
+            "msg".to_string(),
+            vec![ContentBlock::Thinking(ThinkingBlock::new("summary", "sig"))],
+            KnownModel::ClaudeOpus48.into(),
+            Usage::new(10, 20),
+        );
+        let mut renderer = CapturingRenderer::default();
+
+        render_unstreamed_thinking_blocks(&mut renderer, &(), true, &message, &HashSet::from([0]));
+
+        assert!(renderer.thinking.is_empty());
     }
 
     #[test]

--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -291,11 +291,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                         ChatCommand::Effort(effort) => {
                             session.config_mut().set_effort(Some(effort));
-                            let label = match effort {
-                                Effort::Low => "low",
-                                Effort::Medium => "medium",
-                                Effort::High => "high",
-                            };
+                            let label = describe_effort(effort);
                             terminal.print_info(&context, &format!("Effort level set to {label}."));
                         }
                         ChatCommand::ClearEffort => {
@@ -487,14 +483,7 @@ fn print_stop_sequences(stop_sequences: &[String]) {
 fn describe_thinking(stats: &claudius::chat::SessionStats) -> String {
     match stats.thinking_config {
         Some(ThinkingConfig::Adaptive | ThinkingConfig::AdaptiveWithDisplay { .. }) => {
-            let effort = stats
-                .effort
-                .map(|e| match e {
-                    Effort::Low => "low",
-                    Effort::Medium => "medium",
-                    Effort::High => "high",
-                })
-                .unwrap_or("default");
+            let effort = stats.effort.map(describe_effort).unwrap_or("default");
             format!(
                 "adaptive (effort: {effort}{})",
                 describe_display(stats.thinking_config.and_then(|config| config.display()))
@@ -510,6 +499,16 @@ fn describe_thinking(stats: &claudius::chat::SessionStats) -> String {
             )
         }
         Some(ThinkingConfig::Disabled) | None => "disabled".to_string(),
+    }
+}
+
+fn describe_effort(effort: Effort) -> &'static str {
+    match effort {
+        Effort::Low => "low",
+        Effort::Medium => "medium",
+        Effort::High => "high",
+        Effort::XHigh => "xhigh",
+        Effort::Max => "max",
     }
 }
 

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -271,7 +271,7 @@ fn parse_thinking_command(argument: Option<&str>) -> ChatCommand {
 fn parse_effort_command(argument: Option<&str>) -> ChatCommand {
     let Some(arg) = argument else {
         return ChatCommand::Invalid(
-            "/effort expects 'low', 'medium', 'high', or 'clear'".to_string(),
+            "/effort expects 'low', 'medium', 'high', 'xhigh', 'max', or 'clear'".to_string(),
         );
     };
 
@@ -280,10 +280,12 @@ fn parse_effort_command(argument: Option<&str>) -> ChatCommand {
         "low" => ChatCommand::Effort(crate::types::Effort::Low),
         "medium" | "med" => ChatCommand::Effort(crate::types::Effort::Medium),
         "high" => ChatCommand::Effort(crate::types::Effort::High),
+        "xhigh" | "x-high" | "extra-high" => ChatCommand::Effort(crate::types::Effort::XHigh),
+        "max" | "maximum" => ChatCommand::Effort(crate::types::Effort::Max),
         "clear" | "off" | "none" => ChatCommand::ClearEffort,
-        _ => {
-            ChatCommand::Invalid("/effort expects 'low', 'medium', 'high', or 'clear'".to_string())
-        }
+        _ => ChatCommand::Invalid(
+            "/effort expects 'low', 'medium', 'high', 'xhigh', 'max', or 'clear'".to_string(),
+        ),
     }
 }
 
@@ -314,7 +316,7 @@ pub fn help_text() -> &'static str {
   /stop clear            Clear all stop sequences
   /stop list             List current stop sequences
   /thinking on|off|adaptive|<n>  Enable/disable extended thinking (or set budget)
-  /effort low|medium|high|clear  Set effort level for adaptive thinking
+  /effort low|medium|high|xhigh|max|clear  Set effort level for adaptive thinking
   /cache on|off          Enable/disable prompt caching
   /spend <dollars>       Set session spend limit in dollars (or 'clear')
   /transcript <file>     Enable auto-saving transcripts (or 'clear')
@@ -446,6 +448,14 @@ mod tests {
         assert_eq!(
             parse_command("/effort high"),
             Some(ChatCommand::Effort(crate::types::Effort::High))
+        );
+        assert_eq!(
+            parse_command("/effort xhigh"),
+            Some(ChatCommand::Effort(crate::types::Effort::XHigh))
+        );
+        assert_eq!(
+            parse_command("/effort max"),
+            Some(ChatCommand::Effort(crate::types::Effort::Max))
         );
         assert_eq!(
             parse_command("/effort clear"),

--- a/src/chat/config.rs
+++ b/src/chat/config.rs
@@ -57,10 +57,10 @@ pub struct ChatArgs {
     #[arrrg(optional, "Thinking mode: adaptive, on, off, or token budget", "MODE")]
     pub thinking: Option<String>,
 
-    /// Effort level for adaptive thinking (low, medium, high).
+    /// Effort level for adaptive thinking (low, medium, high, xhigh, max).
     #[arrrg(
         optional,
-        "Effort level for adaptive thinking (low, medium, high)",
+        "Effort level for adaptive thinking (low, medium, high, xhigh, max)",
         "LEVEL"
     )]
     pub effort: Option<String>,
@@ -98,9 +98,11 @@ fn parse_effort(s: &str) -> Result<Effort, ChatArgsError> {
         "low" => Ok(Effort::Low),
         "medium" | "med" => Ok(Effort::Medium),
         "high" => Ok(Effort::High),
+        "xhigh" | "x-high" | "extra-high" => Ok(Effort::XHigh),
+        "max" | "maximum" => Ok(Effort::Max),
         _ => Err(ChatArgsError {
             message: format!(
-                "invalid value for --effort: '{}' (expected low, medium, or high)",
+                "invalid value for --effort: '{}' (expected low, medium, high, xhigh, or max)",
                 s
             ),
         }),
@@ -614,6 +616,25 @@ mod tests {
             Some(ThinkingConfig::adaptive_summarized())
         );
         assert_eq!(config.effort(), Some(Effort::High));
+    }
+
+    #[test]
+    fn config_from_args_thinking_adaptive_with_max_effort() {
+        let args = ChatArgs {
+            model: Some("claude-opus-4-8".to_string()),
+            thinking: Some("adaptive".to_string()),
+            effort: Some("max".to_string()),
+            ..Default::default()
+        };
+
+        let config = ChatConfig::try_from(args).unwrap();
+
+        assert_eq!(
+            config.thinking_config(),
+            Some(ThinkingConfig::adaptive_summarized())
+        );
+        assert_eq!(config.effort(), Some(Effort::Max));
+        assert_eq!(config.output_config().unwrap().effort, Some(Effort::Max));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,6 +86,21 @@ const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
 
+fn stream_debug_enabled() -> bool {
+    env::var_os("CLAUDIUS_DEBUG_STREAM").is_some()
+}
+
+fn debug_stream_request(url: &str, params: &MessageCreateParams) {
+    if !stream_debug_enabled() {
+        return;
+    }
+
+    match serde_json::to_string_pretty(params) {
+        Ok(body) => eprintln!("[claudius-debug] stream request POST {url}\n{body}"),
+        Err(err) => eprintln!("[claudius-debug] failed to serialize stream request: {err}"),
+    }
+}
+
 fn format_reqwest_error(err: &reqwest::Error) -> String {
     let mut parts = vec![err.to_string()];
     let mut source = StdError::source(err);
@@ -919,6 +934,7 @@ impl Anthropic {
         let response = self
             .retry_with_backoff(|| async {
                 let url = self.build_url("messages");
+                debug_stream_request(&url, params);
 
                 let mut headers = self
                     .headers_with_betas(&all_betas)

--- a/src/render.rs
+++ b/src/render.rs
@@ -299,6 +299,14 @@ impl PlainTextRenderer {
         }
         self.flush();
     }
+
+    fn thinking_prefix(context: &dyn StreamContext) -> &'static str {
+        if context.depth() == 0 && context.label().is_none() {
+            "\n[thinking] "
+        } else {
+            "[thinking] "
+        }
+    }
 }
 
 impl Default for PlainTextRenderer {
@@ -342,17 +350,13 @@ impl Renderer for PlainTextRenderer {
                 self.write_with_indent(context, ANSI_THINKING);
                 self.write_with_indent(context, ANSI_DIM);
                 self.write_with_indent(context, ANSI_ITALIC);
+                self.write_with_indent(context, Self::thinking_prefix(context));
                 self.in_thinking = true;
             }
             self.write_with_indent(context, text);
         } else {
             if !self.in_thinking {
-                let prefix = if context.depth() == 0 && context.label().is_none() {
-                    "\n[thinking] "
-                } else {
-                    "[thinking] "
-                };
-                self.write_with_indent(context, prefix);
+                self.write_with_indent(context, Self::thinking_prefix(context));
                 self.in_thinking = true;
             }
             self.write_with_indent(context, text);

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -259,6 +259,17 @@ pub fn parse_message_stream_event(event: &SseEvent) -> Result<MessageStreamEvent
     }
 }
 
+fn debug_stream_event(event: &SseEvent) {
+    if std::env::var_os("CLAUDIUS_DEBUG_STREAM").is_none() {
+        return;
+    }
+
+    eprintln!(
+        "[claudius-debug] sse event={} data={}",
+        event.event, event.data
+    );
+}
+
 /// Process a stream of bytes into decoded Claudius [`MessageStreamEvent`] values.
 pub fn process_message_stream_sse<S>(
     byte_stream: S,
@@ -266,8 +277,12 @@ pub fn process_message_stream_sse<S>(
 where
     S: Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Unpin + 'static,
 {
-    process_sse(byte_stream)
-        .map(|result| result.and_then(|event| parse_message_stream_event(&event)))
+    process_sse(byte_stream).map(|result| {
+        result.and_then(|event| {
+            debug_stream_event(&event);
+            parse_message_stream_event(&event)
+        })
+    })
 }
 
 /// Extract a complete SSE event from a buffer string with size validation.

--- a/src/types/content_block.rs
+++ b/src/types/content_block.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 use crate::types::{
     DocumentBlock, ImageBlock, RedactedThinkingBlock, ServerToolUseBlock, TextBlock, ThinkingBlock,
@@ -9,7 +10,7 @@ use crate::types::{
 ///
 /// This enum represents the different types of content blocks that can be included
 /// in a message's content.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ContentBlock {
     /// A block of text content
@@ -47,6 +48,58 @@ pub enum ContentBlock {
     /// A block containing redacted thinking data
     #[serde(rename = "redacted_thinking")]
     RedactedThinking(RedactedThinkingBlock),
+}
+
+impl<'de> Deserialize<'de> for ContentBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let block_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?
+            .to_string();
+
+        match block_type.as_str() {
+            "text" => from_value(value).map(ContentBlock::Text),
+            "image" => from_value(value).map(ContentBlock::Image),
+            "tool_use" => from_value(value).map(ContentBlock::ToolUse),
+            "server_tool_use" => from_value(value).map(ContentBlock::ServerToolUse),
+            "web_search_tool_result" => from_value(value).map(ContentBlock::WebSearchToolResult),
+            "tool_result" => from_value(value).map(ContentBlock::ToolResult),
+            "document" => from_value(value).map(ContentBlock::Document),
+            "thinking" | "thinking_summary" | "summary" => {
+                from_value(value).map(ContentBlock::Thinking)
+            }
+            "redacted_thinking" => from_value(value).map(ContentBlock::RedactedThinking),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &[
+                    "text",
+                    "image",
+                    "tool_use",
+                    "server_tool_use",
+                    "web_search_tool_result",
+                    "tool_result",
+                    "document",
+                    "thinking",
+                    "thinking_summary",
+                    "summary",
+                    "redacted_thinking",
+                ],
+            )),
+        }
+    }
+}
+
+fn from_value<T, E>(value: Value) -> Result<T, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    serde_json::from_value(value).map_err(E::custom)
 }
 
 impl ContentBlock {
@@ -293,6 +346,18 @@ mod tests {
         let expected = r#"{"type":"thinking","signature":"abc123signature","thinking":"Let me think through this problem step by step..."}"#;
 
         assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn thinking_summary_block_deserializes_as_thinking() {
+        let json = r#"{"type":"thinking_summary","summary":"Condensed reasoning."}"#;
+        let content_block: ContentBlock = serde_json::from_str(json).unwrap();
+
+        let thinking = content_block
+            .as_thinking()
+            .expect("summary block should deserialize as thinking");
+        assert_eq!(thinking.signature, "");
+        assert_eq!(thinking.thinking, "Condensed reasoning.");
     }
 
     #[test]

--- a/src/types/content_block_delta.rs
+++ b/src/types/content_block_delta.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 use crate::types::{CitationsDelta, InputJsonDelta, SignatureDelta, TextDelta, ThinkingDelta};
 
@@ -6,7 +7,7 @@ use crate::types::{CitationsDelta, InputJsonDelta, SignatureDelta, TextDelta, Th
 ///
 /// This type is used for streaming responses from the API, where content blocks
 /// are updated incrementally.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "type")]
 pub enum ContentBlockDelta {
     /// A text delta.
@@ -28,6 +29,64 @@ pub enum ContentBlockDelta {
     /// A signature delta.
     #[serde(rename = "signature_delta")]
     SignatureDelta(SignatureDelta),
+}
+
+impl<'de> Deserialize<'de> for ContentBlockDelta {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let delta_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?
+            .to_string();
+
+        match delta_type.as_str() {
+            "text_delta" => from_value(value).map(ContentBlockDelta::TextDelta),
+            "input_json_delta" => from_value(value).map(ContentBlockDelta::InputJsonDelta),
+            "citations_delta" => from_value(value).map(ContentBlockDelta::CitationsDelta),
+            "thinking_delta" | "summary_delta" | "thinking_summary_delta" => {
+                from_value(value).map(ContentBlockDelta::ThinkingDelta)
+            }
+            "signature_delta" => from_value(value).map(ContentBlockDelta::SignatureDelta),
+            other if is_thinking_like_delta(other) => {
+                let thinking_delta: ThinkingDelta = from_value(value)?;
+                if thinking_delta.thinking.is_empty() {
+                    Err(serde::de::Error::custom(format!(
+                        "unknown thinking delta type {other:?} did not contain text"
+                    )))
+                } else {
+                    Ok(ContentBlockDelta::ThinkingDelta(thinking_delta))
+                }
+            }
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &[
+                    "text_delta",
+                    "input_json_delta",
+                    "citations_delta",
+                    "thinking_delta",
+                    "summary_delta",
+                    "thinking_summary_delta",
+                    "signature_delta",
+                ],
+            )),
+        }
+    }
+}
+
+fn from_value<T, E>(value: Value) -> Result<T, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    serde_json::from_value(value).map_err(E::custom)
+}
+
+fn is_thinking_like_delta(delta_type: &str) -> bool {
+    delta_type.contains("thinking") || delta_type.contains("summary")
 }
 
 impl ContentBlockDelta {
@@ -165,6 +224,38 @@ mod tests {
                 assert_eq!(text_delta.text, "Hello world");
             }
             _ => panic!("Expected TextDelta variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_summary_delta_as_thinking_delta() {
+        let json = json!({
+            "summary": "A compact thinking summary.",
+            "type": "summary_delta"
+        });
+
+        let delta: ContentBlockDelta = from_value(json).unwrap();
+        match delta {
+            ContentBlockDelta::ThinkingDelta(thinking_delta) => {
+                assert_eq!(thinking_delta.thinking, "A compact thinking summary.");
+            }
+            _ => panic!("Expected ThinkingDelta variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_thinking_summary_delta_as_thinking_delta() {
+        let json = json!({
+            "text": "Thinking summary text.",
+            "type": "thinking_summary_delta"
+        });
+
+        let delta: ContentBlockDelta = from_value(json).unwrap();
+        match delta {
+            ContentBlockDelta::ThinkingDelta(thinking_delta) => {
+                assert_eq!(thinking_delta.thinking, "Thinking summary text.");
+            }
+            _ => panic!("Expected ThinkingDelta variant"),
         }
     }
 }

--- a/src/types/output_config.rs
+++ b/src/types/output_config.rs
@@ -11,10 +11,15 @@ use crate::types::OutputFormat;
 pub enum Effort {
     /// Low effort - minimal thinking for simple tasks
     Low,
-    /// Medium effort - moderate thinking (default)
+    /// Medium effort - moderate thinking
     Medium,
-    /// High effort - thorough thinking for complex tasks
+    /// High effort - thorough thinking for complex tasks; API default
     High,
+    /// Extra-high effort - extended capability for long-horizon work.
+    #[serde(rename = "xhigh")]
+    XHigh,
+    /// Maximum effort - always think with no constraints on thinking depth.
+    Max,
 }
 
 /// Output configuration for API requests.
@@ -82,6 +87,8 @@ mod tests {
         assert_eq!(to_value(Effort::Low).unwrap(), json!("low"));
         assert_eq!(to_value(Effort::Medium).unwrap(), json!("medium"));
         assert_eq!(to_value(Effort::High).unwrap(), json!("high"));
+        assert_eq!(to_value(Effort::XHigh).unwrap(), json!("xhigh"));
+        assert_eq!(to_value(Effort::Max).unwrap(), json!("max"));
     }
 
     #[test]
@@ -94,6 +101,12 @@ mod tests {
 
         let high: Effort = serde_json::from_value(json!("high")).unwrap();
         assert_eq!(high, Effort::High);
+
+        let xhigh: Effort = serde_json::from_value(json!("xhigh")).unwrap();
+        assert_eq!(xhigh, Effort::XHigh);
+
+        let max: Effort = serde_json::from_value(json!("max")).unwrap();
+        assert_eq!(max, Effort::Max);
     }
 
     #[test]

--- a/src/types/thinking_block.rs
+++ b/src/types/thinking_block.rs
@@ -35,10 +35,10 @@ impl<'de> Deserialize<'de> for ThinkingBlock {
 
 fn extract_thinking_text(value: &Value) -> Option<String> {
     for field in ["thinking", "summary", "text", "content", "summaries"] {
-        if let Some(candidate) = value.get(field) {
-            if let Some(text) = extract_textish(candidate) {
-                return Some(text);
-            }
+        if let Some(candidate) = value.get(field)
+            && let Some(text) = extract_textish(candidate)
+        {
+            return Some(text);
         }
     }
     None

--- a/src/types/thinking_block.rs
+++ b/src/types/thinking_block.rs
@@ -1,15 +1,63 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 /// A block containing model thinking details.
 ///
 /// ThinkingBlocks contain internal reasoning or deliberation from the model.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ThinkingBlock {
     /// A signature for the thinking (typically a hash).
     pub signature: String,
 
     /// The thinking content.
     pub thinking: String,
+}
+
+impl<'de> Deserialize<'de> for ThinkingBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let signature = value
+            .get("signature")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let thinking = extract_thinking_text(&value).unwrap_or_default();
+
+        Ok(Self {
+            signature,
+            thinking,
+        })
+    }
+}
+
+fn extract_thinking_text(value: &Value) -> Option<String> {
+    for field in ["thinking", "summary", "text", "content", "summaries"] {
+        if let Some(candidate) = value.get(field) {
+            if let Some(text) = extract_textish(candidate) {
+                return Some(text);
+            }
+        }
+    }
+    None
+}
+
+fn extract_textish(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(extract_textish)
+                .collect::<Vec<_>>()
+                .join("\n");
+            if text.is_empty() { None } else { Some(text) }
+        }
+        Value::Object(_) => extract_thinking_text(value),
+        _ => None,
+    }
 }
 
 impl ThinkingBlock {
@@ -55,6 +103,24 @@ mod tests {
             thinking_block.thinking,
             "Let me think through this problem step by step..."
         );
+    }
+
+    #[test]
+    fn deserialization_allows_missing_signature_on_stream_start() {
+        let json = r#"{"thinking":"","type":"thinking"}"#;
+        let thinking_block: ThinkingBlock = serde_json::from_str(json).unwrap();
+
+        assert_eq!(thinking_block.signature, "");
+        assert_eq!(thinking_block.thinking, "");
+    }
+
+    #[test]
+    fn deserialization_accepts_summary_text() {
+        let json = r#"{"summary":"Condensed thinking summary.","type":"thinking"}"#;
+        let thinking_block: ThinkingBlock = serde_json::from_str(json).unwrap();
+
+        assert_eq!(thinking_block.signature, "");
+        assert_eq!(thinking_block.thinking, "Condensed thinking summary.");
     }
 
     #[test]

--- a/src/types/thinking_delta.rs
+++ b/src/types/thinking_delta.rs
@@ -22,10 +22,10 @@ impl<'de> Deserialize<'de> for ThinkingDelta {
 
 fn extract_thinking_text(value: &Value) -> Option<String> {
     for field in ["thinking", "summary", "text", "content"] {
-        if let Some(candidate) = value.get(field) {
-            if let Some(text) = extract_textish(candidate) {
-                return Some(text);
-            }
+        if let Some(candidate) = value.get(field)
+            && let Some(text) = extract_textish(candidate)
+        {
+            return Some(text);
         }
     }
     None

--- a/src/types/thinking_delta.rs
+++ b/src/types/thinking_delta.rs
@@ -1,10 +1,50 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 /// A thinking delta, representing a piece of thinking in a streaming response.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ThinkingDelta {
     /// The thinking content.
     pub thinking: String,
+}
+
+impl<'de> Deserialize<'de> for ThinkingDelta {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Ok(Self {
+            thinking: extract_thinking_text(&value).unwrap_or_default(),
+        })
+    }
+}
+
+fn extract_thinking_text(value: &Value) -> Option<String> {
+    for field in ["thinking", "summary", "text", "content"] {
+        if let Some(candidate) = value.get(field) {
+            if let Some(text) = extract_textish(candidate) {
+                return Some(text);
+            }
+        }
+    }
+    None
+}
+
+fn extract_textish(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(extract_textish)
+                .collect::<Vec<_>>()
+                .join("");
+            if text.is_empty() { None } else { Some(text) }
+        }
+        Value::Object(_) => extract_thinking_text(value),
+        _ => None,
+    }
 }
 
 impl ThinkingDelta {
@@ -48,6 +88,26 @@ mod tests {
 
         let delta: ThinkingDelta = serde_json::from_value(json).unwrap();
         assert_eq!(delta.thinking, "Let me think about this...");
+    }
+
+    #[test]
+    fn thinking_delta_deserialization_accepts_summary() {
+        let json = json!({
+            "summary": "Summarized thinking..."
+        });
+
+        let delta: ThinkingDelta = serde_json::from_value(json).unwrap();
+        assert_eq!(delta.thinking, "Summarized thinking...");
+    }
+
+    #[test]
+    fn thinking_delta_deserialization_accepts_text() {
+        let json = json!({
+            "text": "Text-shaped thinking..."
+        });
+
+        let delta: ThinkingDelta = serde_json::from_value(json).unwrap();
+        assert_eq!(delta.thinking, "Text-shaped thinking...");
     }
 
     #[test]


### PR DESCRIPTION
Anthropic streams extended thinking as summary-shaped payloads whose
delta and block types vary (summary, thinking_summary, summary_delta,
etc.). Decode these leniently and surface them through the renderer.

Types:
- Add Effort::XHigh and Effort::Max variants and wire them through the
  chat CLI argument parser, /effort command, and effort descriptions.
- Hand-roll Deserialize for ThinkingBlock and ThinkingDelta so missing
  signatures and summary/text/content field shapes decode to thinking
  text instead of failing.
- Hand-roll Deserialize for ContentBlock and ContentBlockDelta to map
  thinking_summary/summary block types and summary/thinking-like delta
  types onto the existing Thinking variants.

Rendering:
- Track active thinking blocks during streaming so text deltas on a
  thinking block render as thinking, and replay any unstreamed thinking
  blocks from the final message before finishing the response.
- Factor out PlainTextRenderer::thinking_prefix so the prefix is shared
  between the streaming and buffered paths.

Debugging:
- Add a CLAUDIUS_DEBUG_STREAM env var that logs the outgoing stream
  request body and each decoded SSE event to stderr.

Co-authored-by: AI
