### PR TITLE
feat(types): add server-side fallbacks request parameter

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1781,6 +1781,15 @@ pub trait Agent: Send + Sync + Sized {
         None
     }
 
+    /// Returns the models to fall back to if a request is refused.
+    ///
+    /// When a model with safety classifiers declines a request with
+    /// `stop_reason: "refusal"`, the API can transparently retry against these models
+    /// in order. Server-side fallback is in beta and requires the `fallbacks` beta header.
+    async fn fallbacks(&self) -> Option<Vec<Model>> {
+        None
+    }
+
     /// Returns the filesystem implementation for this agent.
     async fn filesystem(&self) -> Option<&dyn FileSystem> {
         None
@@ -2171,6 +2180,7 @@ pub trait Agent: Send + Sync + Sized {
             temperature: self.temperature().await,
             top_k: self.top_k().await,
             top_p: self.top_p().await,
+            fallbacks: self.fallbacks().await,
             stream,
             tool_choice: self.tool_choice().await,
             tools,

--- a/src/bin/median-text.rs
+++ b/src/bin/median-text.rs
@@ -45,6 +45,7 @@ Output the corrected/unified document and only the corrected/unified document.
         tool_choice: None,
         top_k: None,
         top_p: None,
+        fallbacks: None,
         betas: None,
     };
     let client = Anthropic::new(None).expect("could not create anthropic client");

--- a/src/types/message_create_params.rs
+++ b/src/types/message_create_params.rs
@@ -160,6 +160,18 @@ pub struct MessageCreateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
 
+    /// Models to fall back to if this request is refused.
+    ///
+    /// When a model with safety classifiers (such as Claude Fable 5) declines a request
+    /// with `stop_reason: "refusal"`, the API can transparently retry the request against
+    /// the models listed here, in order, and return the first successful response.
+    ///
+    /// Server-side fallback is in beta and requires the `fallbacks` beta header. See
+    /// [server-side fallback](https://docs.anthropic.com/en/docs/build-with-claude/refusals-and-fallback#server-side-fallback)
+    /// for details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallbacks: Option<Vec<Model>>,
+
     /// Whether to incrementally stream the response using server-sent events.
     ///
     /// See [streaming](https://docs.anthropic.com/en/api/messages-streaming) for
@@ -215,6 +227,7 @@ impl MessageCreateParams {
             tools: None,
             top_k: None,
             top_p: None,
+            fallbacks: None,
             stream: false,
             betas: None,
         }
@@ -238,6 +251,7 @@ impl MessageCreateParams {
             tools: None,
             top_k: None,
             top_p: None,
+            fallbacks: None,
             stream: true,
             betas: None,
         }
@@ -359,6 +373,25 @@ impl MessageCreateParams {
     /// Sets the streaming option.
     pub fn with_stream(mut self, stream: bool) -> Self {
         self.stream = stream;
+        self
+    }
+
+    /// Set the models to fall back to if this request is refused.
+    ///
+    /// Replaces any previously configured fallbacks. Server-side fallback is in beta and
+    /// requires the `fallbacks` beta header.
+    pub fn with_fallbacks(mut self, fallbacks: impl IntoIterator<Item = impl Into<Model>>) -> Self {
+        self.fallbacks = Some(fallbacks.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Add a single fallback model for this request.
+    ///
+    /// Appends to any previously configured fallbacks, preserving order.
+    pub fn with_fallback(mut self, fallback: impl Into<Model>) -> Self {
+        self.fallbacks
+            .get_or_insert_with(Vec::new)
+            .push(fallback.into());
         self
     }
 
@@ -660,6 +693,7 @@ impl Default for MessageCreateParams {
             tools: None,
             top_k: None,
             top_p: None,
+            fallbacks: None,
             stream: false,
             betas: None,
         }
@@ -1012,6 +1046,74 @@ mod tests {
         assert!(
             json.get("betas").is_none(),
             "betas should not appear in serialized JSON"
+        );
+    }
+
+    #[test]
+    fn fallbacks_none_by_default() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeFable5);
+        assert_eq!(params.fallbacks, None);
+
+        // Omitted from serialized JSON when unset.
+        let json = to_value(&params).unwrap();
+        assert!(json.get("fallbacks").is_none());
+    }
+
+    #[test]
+    fn with_fallbacks_replaces() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeFable5)
+            .with_fallbacks([KnownModel::ClaudeSonnet45, KnownModel::ClaudeHaiku45]);
+
+        assert_eq!(
+            params.fallbacks,
+            Some(vec![
+                Model::Known(KnownModel::ClaudeSonnet45),
+                Model::Known(KnownModel::ClaudeHaiku45),
+            ])
+        );
+    }
+
+    #[test]
+    fn with_fallback_appends_in_order() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeFable5)
+            .with_fallback(KnownModel::ClaudeSonnet45)
+            .with_fallback(KnownModel::ClaudeHaiku45);
+
+        assert_eq!(
+            params.fallbacks,
+            Some(vec![
+                Model::Known(KnownModel::ClaudeSonnet45),
+                Model::Known(KnownModel::ClaudeHaiku45),
+            ])
+        );
+    }
+
+    #[test]
+    fn fallbacks_serialization() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeFable5)
+            .with_fallbacks([KnownModel::ClaudeSonnet45]);
+
+        let json = to_value(&params).unwrap();
+        assert_eq!(json.get("fallbacks").unwrap(), &json!(["claude-sonnet-4-5"]));
+    }
+
+    #[test]
+    fn fallbacks_deserialization() {
+        let json = json!({
+            "max_tokens": 1024,
+            "messages": [{ "role": "user", "content": "Hello" }],
+            "model": "claude-fable-5",
+            "stream": false,
+            "fallbacks": ["claude-sonnet-4-5", "claude-haiku-4-5"]
+        });
+
+        let params: MessageCreateParams = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            params.fallbacks,
+            Some(vec![
+                Model::Known(KnownModel::ClaudeSonnet45),
+                Model::Known(KnownModel::ClaudeHaiku45),
+            ])
         );
     }
 }


### PR DESCRIPTION
Claude Fable 5 ships with safety classifiers that can decline a request
with stop_reason: "refusal". The Messages API can transparently retry
such requests against other models via the (beta) fallbacks parameter.

Add an optional fallbacks: Option<Vec<Model>> field to
MessageCreateParams, serialized only when set, plus with_fallbacks
(replace) and with_fallback (append, order-preserving) builders.

Wire a fallbacks() method into the Agent trait alongside the other
configurable request parameters, defaulting to None, and pass it through
when building requests.

The remaining Fable/Mythos 5 features (refusal stop reason, adaptive
thinking, thinking display omitted/summarized, effort incl. xhigh,
vision) already exist; task-budgets and context-management are usable
today via the generic with_beta header API.

Co-authored-by: AI
