### PR TITLE
feat: add system MessageRole and insert via /system

### DIFF
--- a/src/bin/claudius-chat.rs
+++ b/src/bin/claudius-chat.rs
@@ -42,9 +42,7 @@ use claudius::chat::{
     ChatAgent, ChatArgs, ChatCommand, ChatConfig, ChatSession, PlainTextRenderer, help_text,
     parse_command,
 };
-use claudius::{
-    Anthropic, Effort, Model, StopReason, SystemPrompt, ThinkingConfig, ThinkingDisplay,
-};
+use claudius::{Anthropic, Effort, Model, StopReason, ThinkingConfig, ThinkingDisplay};
 use claudius::{OperatorLine, Renderer, StreamContext};
 
 struct ChatTerminal {
@@ -210,13 +208,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             terminal
                                 .print_info(&context, &format!("Model changed to: {}", model_name));
                         }
-                        ChatCommand::System(prompt) => {
-                            session.template_mut().system = prompt.clone().map(SystemPrompt::from);
-                            match prompt {
-                                Some(p) => terminal
-                                    .print_info(&context, &format!("System prompt set to: {}", p)),
-                                None => terminal.print_info(&context, "System prompt cleared."),
-                            }
+                        ChatCommand::System(message) => {
+                            session.insert_system_message(message.clone());
+                            terminal.print_info(
+                                &context,
+                                &format!("System message inserted: {}", message),
+                            );
                         }
                         ChatCommand::MaxTokens(value) => {
                             session.template_mut().max_tokens = Some(value);

--- a/src/bin/claudius-render-transcript.rs
+++ b/src/bin/claudius-render-transcript.rs
@@ -126,6 +126,7 @@ fn render_message(out: &mut String, message: &MessageParam) {
     match message.role {
         MessageRole::User => out.push_str("## User\n\n"),
         MessageRole::Assistant => out.push_str("## Assistant\n\n"),
+        MessageRole::System => out.push_str("## System\n\n"),
     }
 
     match &message.content {

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -15,9 +15,11 @@ pub enum ChatCommand {
     /// Change the model.
     Model(String),
 
-    /// Set or clear the system prompt.
-    /// `None` clears the current system prompt.
-    System(Option<String>),
+    /// Insert a system message into the conversation history.
+    ///
+    /// The message is appended with the `system` role and included in the next
+    /// request to the API.
+    System(String),
 
     /// Set the maximum tokens per response.
     MaxTokens(u32),
@@ -129,7 +131,10 @@ pub fn parse_command(input: &str) -> Option<ChatCommand> {
             Some(model) => ChatCommand::Model(model.to_string()),
             None => ChatCommand::Invalid("/model requires a model name".to_string()),
         },
-        "system" => ChatCommand::System(argument.map(|s| s.to_string())),
+        "system" => match argument {
+            Some(message) => ChatCommand::System(message.to_string()),
+            None => ChatCommand::Invalid("/system requires message text".to_string()),
+        },
         "help" | "?" => ChatCommand::Help,
         "quit" | "exit" | "q" => ChatCommand::Quit,
         "stats" | "status" => ChatCommand::Stats,
@@ -307,7 +312,7 @@ pub fn help_text() -> &'static str {
     r#"Available commands:
   /clear                 Clear conversation history
   /model <name>          Change the model (e.g., /model claude-sonnet-4-0)
-  /system [prompt]       Set system prompt (no argument clears it)
+  /system <message>      Insert a system message into the conversation
   /max_tokens <n>        Set maximum response tokens
   /temperature <v>       Set temperature 0.0-1.0 (use 'clear' to reset)
   /top_p <v>             Set top-p 0.0-1.0 (use 'clear' to reset)
@@ -368,11 +373,16 @@ mod tests {
     fn parse_system() {
         assert_eq!(
             parse_command("/system You are a helpful assistant"),
-            Some(ChatCommand::System(Some(
+            Some(ChatCommand::System(
                 "You are a helpful assistant".to_string()
-            )))
+            ))
         );
-        assert_eq!(parse_command("/system"), Some(ChatCommand::System(None)));
+        assert_eq!(
+            parse_command("/system"),
+            Some(ChatCommand::Invalid(
+                "/system requires message text".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -230,6 +230,24 @@ impl<A: ChatAgent> ChatSession<A> {
         }
     }
 
+    /// Inserts a message into the conversation history without contacting the API.
+    ///
+    /// The message becomes part of the transcript and is included in the next
+    /// turn. This is primarily used to interleave system messages (with
+    /// [`MessageRole::System`](crate::MessageRole::System)) into the
+    /// conversation.
+    pub fn push_message(&mut self, message: MessageParam) {
+        self.messages.push(message);
+    }
+
+    /// Inserts a system message into the conversation history.
+    ///
+    /// The message is appended with [`MessageRole::System`](crate::MessageRole::System)
+    /// and is included in the next request to the API.
+    pub fn insert_system_message(&mut self, content: impl Into<String>) {
+        self.messages.push(MessageParam::system(content));
+    }
+
     /// Returns a snapshot of the current conversation history.
     pub fn clone_messages(&self) -> Vec<MessageParam> {
         self.messages.clone()

--- a/src/types/message_param.rs
+++ b/src/types/message_param.rs
@@ -32,6 +32,13 @@ pub enum MessageRole {
 
     /// Assistant role.
     Assistant,
+
+    /// System role.
+    ///
+    /// System messages provide instructions or context that steer the
+    /// assistant's behavior. Unlike the top-level system prompt, a system
+    /// message can be interleaved at any point in the conversation history.
+    System,
 }
 
 impl MessageParam {
@@ -58,6 +65,11 @@ impl MessageParam {
     /// Create a new assistant `MessageParam` with a string content.
     pub fn assistant(content: impl Into<String>) -> Self {
         Self::new_with_string(content.into(), MessageRole::Assistant)
+    }
+
+    /// Create a new system `MessageParam` with a string content.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self::new_with_string(content.into(), MessageRole::System)
     }
 }
 


### PR DESCRIPTION
Anthropic now supports the "system" role in the messages array, allowing
system instructions to be interleaved into the conversation rather than
living only in the top-level system prompt.

Changes:
- Add System variant to MessageRole and a MessageParam::system
  constructor
- Add ChatSession::push_message and insert_system_message to append a
  system message to the transcript without contacting the API
- Repurpose the /system <message> chat command to insert a system
  message into the conversation history (was: set the top-level system
  prompt)
- Render System-role messages in claudius-render-transcript

Co-authored-by: AI
