### PR TITLE
feat: expose model capabilities and token limits on ModelInfo

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -31,6 +31,7 @@ mod message_stream_event;
 mod message_tokens_count;
 mod metadata;
 mod model;
+mod model_capabilities;
 mod model_info;
 mod model_list_params;
 mod model_list_response;
@@ -108,6 +109,10 @@ pub use message_stream_event::MessageStreamEvent;
 pub use message_tokens_count::MessageTokensCount;
 pub use metadata::Metadata;
 pub use model::{KnownModel, Model, TokenRates};
+pub use model_capabilities::{
+    CapabilitySupport, ContextManagementCapability, EffortCapability, ModelCapabilities,
+    ThinkingCapability, ThinkingTypes,
+};
 pub use model_info::{ModelInfo, ModelType};
 pub use model_list_params::ModelListParams;
 pub use model_list_response::ModelListResponse;

--- a/src/types/model_capabilities.rs
+++ b/src/types/model_capabilities.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+
+/// Indicates whether a model capability is supported.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilitySupport {
+    /// Whether the capability is supported.
+    pub supported: bool,
+}
+
+/// Context-management features exposed by the Models API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextManagementCapability {
+    /// Support for clearing thinking blocks.
+    pub clear_thinking_20251015: Option<CapabilitySupport>,
+    /// Support for clearing tool-use blocks.
+    pub clear_tool_uses_20250919: Option<CapabilitySupport>,
+    /// Support for server-side compaction.
+    pub compact_20260112: Option<CapabilitySupport>,
+    /// Whether any context-management strategy is supported.
+    pub supported: bool,
+}
+
+/// Effort levels exposed by the Models API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffortCapability {
+    /// High effort support.
+    pub high: CapabilitySupport,
+    /// Low effort support.
+    pub low: CapabilitySupport,
+    /// Maximum effort support.
+    pub max: CapabilitySupport,
+    /// Medium effort support.
+    pub medium: CapabilitySupport,
+    /// Whether effort control is supported.
+    pub supported: bool,
+    /// Extra-high effort support, when reported.
+    pub xhigh: Option<CapabilitySupport>,
+}
+
+/// Thinking modes exposed by the Models API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThinkingTypes {
+    /// Adaptive thinking support.
+    pub adaptive: CapabilitySupport,
+    /// Manual extended-thinking support.
+    pub enabled: CapabilitySupport,
+}
+
+/// Thinking support exposed by the Models API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThinkingCapability {
+    /// Whether any thinking mode is supported.
+    pub supported: bool,
+    /// Supported thinking configurations.
+    pub types: ThinkingTypes,
+}
+
+/// Capability metadata returned for a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelCapabilities {
+    /// Message Batches API support.
+    pub batch: CapabilitySupport,
+    /// Citation generation support.
+    pub citations: CapabilitySupport,
+    /// Code execution support.
+    pub code_execution: CapabilitySupport,
+    /// Context-management support and strategies.
+    pub context_management: ContextManagementCapability,
+    /// Effort-control support and levels.
+    pub effort: EffortCapability,
+    /// Image input support.
+    pub image_input: CapabilitySupport,
+    /// PDF input support.
+    pub pdf_input: CapabilitySupport,
+    /// Structured output and strict tool-schema support.
+    pub structured_outputs: CapabilitySupport,
+    /// Thinking support and modes.
+    pub thinking: ThinkingCapability,
+}

--- a/src/types/model_info.rs
+++ b/src/types/model_info.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use crate::types::ModelCapabilities;
+
 /// Information about a specific model.
 ///
 /// This struct contains details about an Anthropic model, including its
@@ -9,6 +11,10 @@ use time::OffsetDateTime;
 pub struct ModelInfo {
     /// Unique model identifier.
     pub id: String,
+
+    /// Model capability information, when supplied by the API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ModelCapabilities>,
 
     /// RFC 3339 datetime string representing the time at which the model was released.
     ///
@@ -19,6 +25,14 @@ pub struct ModelInfo {
     /// A human-readable name for the model.
     #[serde(rename = "display_name")]
     pub display_name: String,
+
+    /// Maximum input context window size in tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_input_tokens: Option<u64>,
+
+    /// Maximum accepted value for the Messages API `max_tokens` parameter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
 
     /// Object type.
     ///
@@ -46,8 +60,11 @@ mod tests {
     fn model_info_serialization() {
         let model_info = ModelInfo {
             id: "claude-3-7-sonnet-20250219".to_string(),
+            capabilities: None,
             created_at: datetime!(2025-02-19 0:00:00 UTC),
             display_name: "Claude 3.7 Sonnet".to_string(),
+            max_input_tokens: None,
+            max_tokens: None,
             r#type: ModelType::Model,
         };
 
@@ -75,5 +92,51 @@ mod tests {
         assert_eq!(model_info.created_at, datetime!(2025-02-19 0:00:00 UTC));
         assert_eq!(model_info.display_name, "Claude 3.7 Sonnet");
         assert_eq!(model_info.r#type, ModelType::Model);
+    }
+
+    #[test]
+    fn model_info_deserializes_current_capabilities_and_limits() {
+        let json = serde_json::json!({
+            "id": "claude-opus-5",
+            "capabilities": {
+                "batch": { "supported": true },
+                "citations": { "supported": true },
+                "code_execution": { "supported": true },
+                "context_management": {
+                    "clear_thinking_20251015": { "supported": true },
+                    "clear_tool_uses_20250919": { "supported": true },
+                    "compact_20260112": { "supported": true },
+                    "supported": true
+                },
+                "effort": {
+                    "high": { "supported": true },
+                    "low": { "supported": true },
+                    "max": { "supported": true },
+                    "medium": { "supported": true },
+                    "supported": true,
+                    "xhigh": { "supported": true }
+                },
+                "image_input": { "supported": true },
+                "pdf_input": { "supported": true },
+                "structured_outputs": { "supported": true },
+                "thinking": {
+                    "supported": true,
+                    "types": {
+                        "adaptive": { "supported": true },
+                        "enabled": { "supported": true }
+                    }
+                }
+            },
+            "created_at": "2026-07-24T00:00:00Z",
+            "display_name": "Claude Opus 5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,
+            "type": "model"
+        });
+
+        let model: ModelInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(model.max_input_tokens, Some(1_000_000));
+        assert_eq!(model.max_tokens, Some(128_000));
+        assert!(model.capabilities.unwrap().effort.max.supported);
     }
 }

--- a/src/types/model_list_response.rs
+++ b/src/types/model_list_response.rs
@@ -76,8 +76,11 @@ mod tests {
     fn model_list_response_serialization() {
         let model_info = ModelInfo {
             id: "claude-3-7-sonnet-20250219".to_string(),
+            capabilities: None,
             created_at: datetime!(2025-02-19 0:00:00 UTC),
             display_name: "Claude 3.7 Sonnet".to_string(),
+            max_input_tokens: None,
+            max_tokens: None,
             r#type: ModelType::Model,
         };
 
@@ -129,8 +132,11 @@ mod tests {
     fn model_list_response_accessors() {
         let model_info = ModelInfo {
             id: "claude-3-7-sonnet-20250219".to_string(),
+            capabilities: None,
             created_at: datetime!(2025-02-19 0:00:00 UTC),
             display_name: "Claude 3.7 Sonnet".to_string(),
+            max_input_tokens: None,
+            max_tokens: None,
             r#type: ModelType::Model,
         };
 


### PR DESCRIPTION
Add a ModelCapabilities type mirroring the Models API capability
metadata (batch, citations, code execution, context management,
effort, image/PDF input, structured outputs, and thinking) and surface
it on ModelInfo along with the max_input_tokens and max_tokens limits.

All new fields are optional and skipped when absent, so existing
responses continue to deserialize unchanged.

Co-authored-by: AI
